### PR TITLE
Better publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,5 @@ jobs:
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true
         env:
-          ORG_GRADLE_PROJECT_GitHubPackagesUsername: ${{ github.actor }}
-          ORG_GRADLE_PROJECT_GitHubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
+            name = "githubPackages"
             setUrl("https://maven.pkg.github.com/RedMadRobot/gradle-infrastructure")
             credentials(PasswordCredentials::class)
         }

--- a/src/main/kotlin/PublishPlugin.kt
+++ b/src/main/kotlin/PublishPlugin.kt
@@ -1,11 +1,13 @@
 package com.redmadrobot.build
 
-import com.redmadrobot.build.extension.rmrNexus
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.register
 
 class PublishPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -16,7 +18,6 @@ class PublishPlugin : Plugin<Project> {
         } else {
             configurePublication()
         }
-        configureNexusRepository()
     }
 }
 
@@ -53,14 +54,6 @@ private fun Project.configurePublication() {
     publishing {
         publications.create<MavenPublication>("maven") {
             from(components["java"])
-        }
-    }
-}
-
-private fun Project.configureNexusRepository() {
-    publishing {
-        repositories {
-            rmrNexus()
         }
     }
 }

--- a/src/main/kotlin/extension/PublishingPredicates.kt
+++ b/src/main/kotlin/extension/PublishingPredicates.kt
@@ -1,0 +1,16 @@
+package com.redmadrobot.build.extension
+
+import org.gradle.api.Project
+
+/** Returns `true` if version contains `-SNAPSHOT` suffix. */
+val Project.isSnapshotVersion: Boolean
+    get() = version.toString().endsWith("-SNAPSHOT")
+
+/**
+ * Checks that credentials for the repository with given [name] are exist.
+ *
+ * See: https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:handling_credentials
+ */
+fun Project.credentialsExist(name: String): Boolean {
+    return hasProperty("${name}Username") && hasProperty("${name}Password")
+}

--- a/src/main/kotlin/extension/RedmadrobotExtension.kt
+++ b/src/main/kotlin/extension/RedmadrobotExtension.kt
@@ -11,7 +11,7 @@ open class RedmadrobotExtension(objects: ObjectFactory) {
         const val NAME = "redmadrobot"
 
         // Relative to root project directory.
-        internal const val DEFAULT_CONFIGS_DIR = "configs/"
+        internal const val DEFAULT_CONFIGS_DIR = "config/"
 
         // Relative to root project build directory.
         internal const val DEFAULT_REPORTS_DIR = "reports/"

--- a/src/main/kotlin/extension/Repositories.kt
+++ b/src/main/kotlin/extension/Repositories.kt
@@ -1,19 +1,87 @@
 package com.redmadrobot.build.extension
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.kotlin.dsl.credentials
+import org.gradle.kotlin.dsl.maven
 
 /**
  * Adds RMR Nexus repo with name "rmrNexus".
  * Credentials should be provided through project properties `rmrNexusUsername` and `rmrNexusPassword`.
  *
  * See: https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:handling_credentials
+ *
+ * The URL used for the repository is `https://nexus.redmadrobot.com/repository/android/`
+ *
+ * Example:
+ * ```
+ * repositories {
+ *     rmrNexus()
+ * }
+ * ```
  */
-fun RepositoryHandler.rmrNexus() {
-    maven {
+fun RepositoryHandler.rmrNexus(configure: MavenArtifactRepository.() -> Unit = {}): MavenArtifactRepository {
+    return maven("https://nexus.redmadrobot.com/repository/android/") {
         name = "rmrNexus"
-        setUrl("https://nexus.redmadrobot.com/repository/android/")
         credentials(PasswordCredentials::class)
+        apply(configure)
+    }
+}
+
+/**
+ * Adds GitHub Packages repository for the specified [repoName].
+ * Credentials should be provided through project properties `githubPackagesUsername` and  `githubPackagesPassword`.
+ *
+ * See: https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:handling_credentials
+ *
+ * Example:
+ * ```
+ * repositories {
+ *     githubPackages("RedMadRobot/gradle-infrastructure")
+ * }
+ * ```
+ */
+fun RepositoryHandler.githubPackages(
+    repoName: String,
+    configure: MavenArtifactRepository.() -> Unit = {}
+): MavenArtifactRepository {
+    return maven("https://maven.pkg.github.com/$repoName") {
+        name = "githubPackages"
+        credentials(PasswordCredentials::class)
+        apply(configure)
+    }
+}
+
+/**
+ * Adds RMR Bintray repository to .
+ *
+ * Example:
+ * ```
+ * repositories {
+ *     rmrBintray()
+ * }
+ * ```
+ */
+fun RepositoryHandler.rmrBintray(configure: MavenArtifactRepository.() -> Unit = {}): MavenArtifactRepository {
+    return maven("https://dl.bintray.com/redmadrobot-opensource/android", configure)
+}
+
+/**
+ * Adds RMR Bintray repository for the specified [packageName].
+ * Credentials should be provided through project properties `bintrayUsername` and  `bintrayPassword`.
+ *
+ * See: https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:handling_credentials
+ */
+fun RepositoryHandler.rmrBintray(
+    packageName: String,
+    publish: Boolean = false,
+    configure: MavenArtifactRepository.() -> Unit = {}
+): MavenArtifactRepository {
+    val params = ";publish=${if (publish) 1 else 0}"
+    return maven("https://api.bintray.com/maven/redmadrobot-opensource/android/$packageName/$params") {
+        name = "bintray"
+        credentials(PasswordCredentials::class)
+        apply(configure)
     }
 }


### PR DESCRIPTION
Now you should specify publishing repositories manually. You can also use predicates for publication:
```kotlin
publishing {
    repositories {
        rmrNexus()
        githubPackages("RedMadRobot/gradle-infrastructure")
        // Publication with conditions
        if (!isSnapshotVersion && credentialsExist("bintray")) rmrBintray("infrastructure")
    }
}
```

You can use the same extensions for dependencies repositories:
```kotlin
dependencies {
    // ...
}

repositories {
    rmrNexus()
    githubPackages("RedMadRobot/gradle-infrastructure")
    rmrBintray() // Without package name
}
```

Fixes #2, #3, #4 