### PR TITLE
android-library: Explicit API mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,10 @@ kotlinDslPluginOptions {
 
 gradlePlugin {
     plugins {
+        register("root-project") {
+            id = "redmadrobot.root-project"
+            implementationClass = "com.redmadrobot.build.RootProjectPlugin"
+        }
         register("application") {
             id = "redmadrobot.application"
             implementationClass = "com.redmadrobot.build.AndroidApplicationPlugin"

--- a/samples/android-application-multi/build.gradle.kts
+++ b/samples/android-application-multi/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("redmadrobot.root-project")
+}
+
+// Common configurations for all modules
+redmadrobot {
+    android {
+        minSdk = 24
+        targetSdk = 30
+    }
+}

--- a/samples/android-application-multi/module2/build.gradle.kts
+++ b/samples/android-application-multi/module2/build.gradle.kts
@@ -2,6 +2,9 @@ plugins {
     id("redmadrobot.android-library")
 }
 
+// Explicit API is enabled by default, but we can disable it if need
+kotlin.explicitApi = null
+
 dependencies {
     // Kotlin already added as dependency to the project
     // ...

--- a/samples/android-application-multi/module2/src/main/kotlin/Module2.kt
+++ b/samples/android-application-multi/module2/src/main/kotlin/Module2.kt
@@ -2,9 +2,9 @@ package com.redmadrobot.samples.module1
 
 import android.util.Log
 
-public object Module2 {
+object Module2 {
 
-    public fun doSomething() {
+    fun doSomething() {
         Log.d("Module2", "Something done!")
     }
 }

--- a/src/main/kotlin/AndroidLibraryPlugin.kt
+++ b/src/main/kotlin/AndroidLibraryPlugin.kt
@@ -3,15 +3,15 @@ package com.redmadrobot.build
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+private const val ARG_EXPLICIT_API = "-Xexplicit-api"
 
 class AndroidLibraryPlugin : BaseAndroidPlugin() {
     override fun apply(target: Project) = with(target) {
         apply(plugin = "com.android.library")
         super.apply(target)
-
-        kotlinCompile {
-            kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
-        }
 
         android<LibraryExtension> {
             buildFeatures {
@@ -23,5 +23,23 @@ class AndroidLibraryPlugin : BaseAndroidPlugin() {
         }
 
         configureKotlinDependencies()
+
+        // Enable Explicit API by default
+        if (kotlin.explicitApi == null) kotlin.explicitApi()
+        afterEvaluate {
+            configureExplicitApi(kotlin.explicitApi)
+        }
     }
+}
+
+private fun Project.configureExplicitApi(mode: ExplicitApiMode?) {
+    if (mode == null) return
+
+    tasks.matching { it is KotlinCompile && !it.name.contains("test", ignoreCase = true) }
+        .configureEach {
+            val options = (this as KotlinCompile).kotlinOptions
+            if (options.freeCompilerArgs.none { it.startsWith(ARG_EXPLICIT_API) }) {
+                options.freeCompilerArgs += mode.toCompilerArg()
+            }
+        }
 }


### PR DESCRIPTION
Explicit API mode is strict by default but now we can disable it if need:
```kotlin
kotlin.explicitApi = null   // If we don't need explicit API mode
kotlin.explicitApiWarning() // If we want to see warnings instead of errors 
```

Closes #14