### PR TITLE
Source sets sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,16 @@ redmadrobot {
 
 ### Share sources between build types
 
-You can use sources from one build type in another build type.  
-For example, you need to use debug panel in both debug and staging builds, and don't want write similar duplicating code for each of these build types.
-You can do it with one line with [mergeSourceSets] extension-function:
+You can share sources between two build types.  
+For example, you need to use debug panel in both debug and staging builds, and don't want to write similar duplicating code for each of these build types.
+You can do it with one line with [addSharedSourceSetRoot] extension-function:
 ```kotlin
 android {
-    mergeSourceSets(BUILD_TYPE_DEBUG to BUILD_TYPE_STAGING)
+    // We need to share sources between debug and staging builds
+    addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING)
+
+    // We can specify name for the source set root if need
+    addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING, name = "debugPanel")
 }
 ```
 
@@ -238,7 +242,7 @@ For major changes, please open an issue first to discuss what you would like to 
 
 [RedmadrobotExtension]: src/main/kotlin/extension/RedmadrobotExtension.kt
 [predicates]: src/main/kotlin/extension/PublishingPredicates.kt
-[mergeSourceSets]: src/main/kotlin/extension/SourceSets.kt
+[addSharedSourceSetRoot]: src/main/kotlin/extension/SourceSets.kt
 
 [bintray]: https://bintray.com/redmadrobot-opensource/android/infrastructure
 [ci]: https://github.com/RedMadRobot/gradle-infrastructure/actions

--- a/src/main/kotlin/extension/SourceSets.kt
+++ b/src/main/kotlin/extension/SourceSets.kt
@@ -52,8 +52,17 @@ public fun BaseExtension.mergeSourceSets(from: String, to: String) {
 }
 
 /**
- * Adds source set root with given [name] shared between [variant1] and [variant2] source sets.
+ * Adds source set root with the given [name], shared between [variant1] and [variant2] source sets.
  * By default [name] is a combination of `variant1` and `variant2` names.
+ * ```
+ *  android {
+ *      // Here we need to share sources between debug and staging builds
+ *      addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING)
+ *
+ *      // We can specify name for the source set root if need
+ *      addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING, name = "debugPanel")
+ *  }
+ * ```
  */
 @Incubating
 public fun BaseExtension.addSharedSourceSetRoot(

--- a/src/main/kotlin/extension/SourceSets.kt
+++ b/src/main/kotlin/extension/SourceSets.kt
@@ -1,9 +1,12 @@
 package com.redmadrobot.build.extension
 
+import com.android.SdkConstants.*
+import com.android.build.api.dsl.AndroidSourceSet
 import com.android.build.gradle.BaseExtension
 import com.redmadrobot.build.BUILD_TYPE_DEBUG
 import com.redmadrobot.build.BUILD_TYPE_RELEASE
 import com.redmadrobot.build.BUILD_TYPE_STAGING
+import org.gradle.api.Incubating
 import org.gradle.kotlin.dsl.get
 
 /**
@@ -37,4 +40,37 @@ public fun BaseExtension.mergeSourceSets(from: String, to: String) {
     val fromSourceSet = sourceSets[from].java
     val toSourceSet = sourceSets[to].java
     toSourceSet.setSrcDirs(fromSourceSet.srcDirs + toSourceSet.srcDirs)
+}
+
+/**
+ * Adds source set root with given [name] shared between [variant1] and [variant2] source sets.
+ * By default [name] is a combination of `variant1` and `variant2` names.
+ */
+@Incubating
+public fun BaseExtension.addSharedSourceSetRoot(
+    variant1: String,
+    variant2: String,
+    name: String = "$variant1${variant2.capitalize()}"
+) {
+    val variant1SourceSets = sourceSets[variant1]
+    val variant2SourceSets = sourceSets[variant2]
+    val root = "src/$name"
+
+    variant1SourceSets.addRoot(root)
+    variant2SourceSets.addRoot(root)
+}
+
+@Suppress("UnstableApiUsage")
+private fun AndroidSourceSet.addRoot(path: String) {
+    java.setSrcDirs(listOf("$path/$FD_JAVA"))
+    resources.setSrcDirs(listOf("$path/$FD_JAVA_RES"))
+    res.setSrcDirs(listOf("$path/$FD_RES"))
+    assets.setSrcDirs(listOf("$path/$FD_ASSETS"))
+    manifest.srcFile("$path/$FN_ANDROID_MANIFEST_XML")
+    aidl.setSrcDirs(listOf("$path/$FD_AIDL"))
+    renderscript.setSrcDirs(listOf("$path/$FD_RENDERSCRIPT"))
+    jni.setSrcDirs(listOf("$path/$FD_JNI"))
+    jniLibs.setSrcDirs(listOf("$path/jniLibs"))
+    shaders.setSrcDirs(listOf("$path/shaders"))
+    mlModels.setSrcDirs(listOf("$path/$FD_ML_MODELS"))
 }

--- a/src/main/kotlin/extension/SourceSets.kt
+++ b/src/main/kotlin/extension/SourceSets.kt
@@ -21,6 +21,11 @@ import org.gradle.kotlin.dsl.get
  *  }
  * ```
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    message = "With mergeSourceSets you're not able to add resources with the same name to both of build types.",
+    replaceWith = ReplaceWith("addSharedSourceSetRoot(mapping.first, mapping.second)")
+)
 public fun BaseExtension.mergeSourceSets(mapping: Pair<String, String>) {
     mergeSourceSets(mapping.first, mapping.second)
 }
@@ -36,6 +41,10 @@ public fun BaseExtension.mergeSourceSets(mapping: Pair<String, String>) {
  *  }
  * ```
  */
+@Deprecated(
+    message = "With mergeSourceSets you're not able to add resources with the same name to both of build types.",
+    replaceWith = ReplaceWith("addSharedSourceSetRoot(from, to)")
+)
 public fun BaseExtension.mergeSourceSets(from: String, to: String) {
     val fromSourceSet = sourceSets[from].java
     val toSourceSet = sourceSets[to].java


### PR DESCRIPTION
Added extension-function  `addSharedSourceSetRoot`. `mergeSourceSets` deprecated now.

The new function adds source set root shared between two source sets.
```kotlin
 android {
     // Here we need to share sources between debug and staging builds
     addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING)

     // We can specify name for the source set root if need
     addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_STAGING, name = "debugPanel")
 }
```

Resolves #19 