### PR TITLE
Explicit root-project application

### DIFF
--- a/samples/android-application-multi/build.gradle.kts
+++ b/samples/android-application-multi/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("redmadrobot.root-project")
+    id("redmadrobot.root-project") version "0.6-SNAPSHOT"
 }
 
 // Common configurations for all modules

--- a/samples/android-application-multi/settings.gradle.kts
+++ b/samples/android-application-multi/settings.gradle.kts
@@ -1,18 +1,9 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         google()
         maven(url = "https://dl.bintray.com/redmadrobot-opensource/android")
-    }
-
-    resolutionStrategy {
-        eachPlugin {
-            // It may be useful to set infrastructure version here.
-            // In this case you don't need to specify it for each of plugins.
-            if (requested.id.namespace == "redmadrobot") {
-                useModule("com.redmadrobot.build:infrastructure:0.5")
-            }
-        }
     }
 }
 

--- a/samples/android-application/app/build.gradle.kts
+++ b/samples/android-application/app/build.gradle.kts
@@ -4,7 +4,7 @@ import com.redmadrobot.build.extension.addSharedSourceSetRoot
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("redmadrobot.application") version "0.6-SNAPSHOT"
+    id("redmadrobot.application")
 }
 
 // Plugin "redmadrobot.application" configures build types, SDK versions, proguard and so on.

--- a/samples/android-application/build.gradle.kts
+++ b/samples/android-application/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("redmadrobot.root-project") version "0.6-SNAPSHOT"
+}

--- a/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/src/main/kotlin/BaseAndroidPlugin.kt
@@ -13,7 +13,7 @@ import java.io.File
 public abstract class BaseAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            rootProject.apply<RootProjectPlugin>()
+            requireRootPlugin()
             apply(plugin = "kotlin-android")
 
             configureKotlin()

--- a/src/main/kotlin/DetektPlugin.kt
+++ b/src/main/kotlin/DetektPlugin.kt
@@ -13,7 +13,7 @@ public class DetektPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {
-            rootProject.apply<RootProjectPlugin>()
+            requireRootPlugin()
             apply(plugin = "io.gitlab.arturbosch.detekt")
 
             configureDependencies()

--- a/src/main/kotlin/KotlinLibraryPlugin.kt
+++ b/src/main/kotlin/KotlinLibraryPlugin.kt
@@ -10,7 +10,7 @@ import org.gradle.kotlin.dsl.repositories
 public class KotlinLibraryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            rootProject.apply<RootProjectPlugin>()
+            requireRootPlugin()
             apply(plugin = "kotlin")
 
             java {

--- a/src/main/kotlin/RootProjectPlugin.kt
+++ b/src/main/kotlin/RootProjectPlugin.kt
@@ -19,3 +19,15 @@ public class RootProjectPlugin : Plugin<Project> {
         rmr.reportsDir.convention(layout.buildDirectory.dir(RedmadrobotExtension.DEFAULT_REPORTS_DIR))
     }
 }
+
+internal fun Project.requireRootPlugin() {
+    check(rootProject.plugins.hasPlugin("redmadrobot.root-project")) {
+        """
+        Plugin 'redmadrobot.root-project' not found. You should apply it to your root project:
+
+        plugins {
+            id("redmadrobot.root-project") version "[LATEST_VERSION_HERE]"
+        }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Now `root-project` plugin should be explicitly applied to the root project.
It makes it possible to specify the infrastructure version in one place and not duplicate it for each of the plugins. Also, it enabled us to configure `redmadrobot` extension in the root project.