### PR TITLE
Fix gradle-plugin publication

### DIFF
--- a/infrastructure/src/main/kotlin/Accessors.kt
+++ b/infrastructure/src/main/kotlin/Accessors.kt
@@ -14,6 +14,8 @@ internal fun Project.publishing(configure: PublishingExtension.() -> Unit) {
     extensions.configure("publishing", configure)
 }
 
+internal val Project.java: JavaPluginExtension get() = extensions.getByName<JavaPluginExtension>("java")
+
 internal fun Project.java(configure: JavaPluginExtension.() -> Unit) {
     extensions.configure("java", configure)
 }

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -17,6 +17,7 @@ public class PublishPlugin : Plugin<Project> {
 
             when {
                 plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
+                plugins.hasPlugin("java-gradle-plugin") -> configurePluginPublication()
                 else -> configurePublication()
             }
         }
@@ -46,11 +47,14 @@ public class PublishPlugin : Plugin<Project> {
         }
     }
 
+    private fun Project.configurePluginPublication() {
+        @Suppress("UnstableApiUsage")
+        java.withSourcesJar()
+    }
+
     private fun Project.configurePublication() {
-        java {
-            @Suppress("UnstableApiUsage")
-            withSourcesJar()
-        }
+        @Suppress("UnstableApiUsage")
+        java.withSourcesJar()
 
         publishing {
             publications.create<MavenPublication>("maven") {

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -10,52 +10,52 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
 
 public class PublishPlugin : Plugin<Project> {
+
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "maven-publish")
 
-            if (plugins.hasPlugin("kotlin-android")) {
-                configureAndroidPublication()
-            } else {
-                configurePublication()
+            when {
+                plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
+                else -> configurePublication()
             }
         }
     }
-}
 
-private fun Project.configureAndroidPublication() {
-    val sourcesJar = tasks.register<Jar>("sourcesJar") {
-        archiveClassifier.set("sources")
-        from(android.sourceSets["main"].java.srcDirs)
+    private fun Project.configureAndroidPublication() {
+        val sourcesJar = tasks.register<Jar>("sourcesJar") {
+            archiveClassifier.set("sources")
+            from(android.sourceSets["main"].java.srcDirs)
+        }
+
+        // Because the components are created only during the afterEvaluate phase, you must
+        // configure your publications using the afterEvaluate() lifecycle method.
+        afterEvaluate {
+            if (version == Project.DEFAULT_VERSION) {
+                version = checkNotNull(android.defaultConfig.versionName) {
+                    "You should specify either project 'version' or 'android.versionName' for publication."
+                }
+            }
+
+            publishing {
+                publications.create<MavenPublication>("maven") {
+                    from(components["release"])
+                    artifact(sourcesJar.get())
+                }
+            }
+        }
     }
 
-    // Because the components are created only during the afterEvaluate phase, you must
-    // configure your publications using the afterEvaluate() lifecycle method.
-    afterEvaluate {
-        if (version == Project.DEFAULT_VERSION) {
-            version = checkNotNull(android.defaultConfig.versionName) {
-                "You should specify either project 'version' or 'android.versionName' for publication."
-            }
+    private fun Project.configurePublication() {
+        java {
+            @Suppress("UnstableApiUsage")
+            withSourcesJar()
         }
 
         publishing {
             publications.create<MavenPublication>("maven") {
-                from(components["release"])
-                artifact(sourcesJar.get())
+                from(components["java"])
             }
-        }
-    }
-}
-
-private fun Project.configurePublication() {
-    java {
-        @Suppress("UnstableApiUsage")
-        withSourcesJar()
-    }
-
-    publishing {
-        publications.create<MavenPublication>("maven") {
-            from(components["java"])
         }
     }
 }


### PR DESCRIPTION
Add only sources if publish added to gradle-plugin project.
Fixes warning:
```
Multiple publications with coordinates '...' are published to repository '...'. The publications will overwrite each other!
```

See https://github.com/gradle/gradle/issues/10384