### PR TITLE
POM configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 ## [Unreleased]
 
+### POM Configuration
+
+Now you can configure common for all modules POM properties in `redmadrobot.publishing` extension.
+There are extension-functions to cover common configuration use-cases.
+
+```kotlin
+redmadrobot {
+    publishing {
+        pom {
+            // Configure <url>, <scm> and <issueManagement> tags for GitHub project by it's name
+            setGitHubProject("RedMadRobot/gradle-infrastructure")
+            
+            licenses { 
+                mit() // Add MIT license
+            }
+            
+            developers {
+                // Shorthand to add a developer
+                developer(id = "jdoe", name = "John Dow", email = "john@doe.com")
+            }
+        }
+    }
+}
+```
+
+Use `publishing` extension in module build script to configure POM for this module.
+Take publication name from `PUBLICATION_NAME` constant.
+
+```kotlin
+publishing {
+    publications {
+        getByName<MavenPublication>(PUBLICATION_NAME) {
+            pom {
+                // Configure POM here
+            }
+        }
+    }
+}
+
+// or even shorter
+publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
+    pom {
+        // Configure POM here
+    }
+}
+```
+
+### Added
+
+- Add javadoc publication for kotlin libraries and gradle plugins
+
 ### Fixed
 
 - Fixed gradle plugins signing

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Application:
 Common publish configurations for both Android and Kotlin libraries.
 
 - Applies plugin `maven-publish`
-- Adds sources to publication
+- Adds sources and javadocs to publication
 
 You should specify publishing repositories manually. You can also use [predicates] for publication:
 ```kotlin
@@ -129,6 +129,8 @@ publishing {
 }
 ```
 
+#### Signing
+
 You can configure publication in extension `redmadrobot.publishing`:
 ```kotlin
 redmadrobot {
@@ -139,7 +141,55 @@ redmadrobot {
 }
 ```
 
-Read more about singing configuration in [Signing Plugin](https://docs.gradle.org/current/userguide/signing_plugin.html#signing_plugin) docs.
+Read more about singing configuration in [Signing Plugin][signing-plugin] docs.
+
+#### Customize POM
+
+You can configure POM properties common for all modules.
+
+> Note: there are extension-functions to simplify common configuration use-cases.
+> All available extensions you can find [here][MavenPom].
+
+```kotlin
+redmadrobot {
+    publishing {
+        pom {
+            // Configure <url>, <scm> and <issueManagement> tags for GitHub project by it's name
+            setGitHubProject("RedMadRobot/gradle-infrastructure")
+            
+            licenses { 
+                mit() // Add MIT license
+            }
+            
+            developers {
+                // Shorthand to add a developer
+                developer(id = "jdoe", name = "John Dow", email = "john@doe.com")
+            }
+        }
+    }
+}
+```
+
+#### Customize publication for module
+
+Use `publishing` extension in module build script to configure publication for the single module.
+Take publication name from `PUBLICATION_NAME` constant.
+Read more in [Maven Publish plugin][maven-publish] docs.
+
+```kotlin
+publishing {
+    publications {
+        getByName<MavenPublication>(PUBLICATION_NAME) {
+            // Configure publication here
+        }
+    }
+}
+
+// or even shorter
+publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
+    // Configure publication here
+}
+```
 
 ### detekt
 
@@ -261,6 +311,7 @@ For major changes, please open an issue first to discuss what you would like to 
 
 [samples]: samples/
 [RedmadrobotExtension]: infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
+[MavenPom]: infrastructure/src/main/kotlin/extension/MavenPom.kt
 [predicates]: infrastructure/src/main/kotlin/extension/PublishingPredicates.kt
 [addSharedSourceSetRoot]: infrastructure/src/main/kotlin/extension/SourceSets.kt
 [lint-options]: https://github.com/RedMadRobot/gradle-infrastructure/blob/2e96c04cbb9d15ca508d1d4b4a8b1e2da4bab6af/infrastructure/src/main/kotlin/AndroidApplicationPlugin.kt#L63-L72
@@ -276,3 +327,5 @@ For major changes, please open an issue first to discuss what you would like to 
 
 [build-features]: https://developer.android.com/reference/tools/gradle-api/com/android/build/api/dsl/BuildFeatures
 [explicit-api]: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors
+[signing-plugin]: https://docs.gradle.org/current/userguide/signing_plugin.html
+[maven-publish]: https://docs.gradle.org/current/userguide/publishing_maven.html

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -12,8 +12,8 @@ import org.gradle.plugins.signing.Sign
 public class PublishPlugin : Plugin<Project> {
 
     public companion object {
-        private const val PUBLICATION_NAME = "maven"
-        private const val PLUGIN_PUBLICATION_NAME = "pluginMaven"
+        public const val PUBLICATION_NAME: String = "maven"
+        public const val PLUGIN_PUBLICATION_NAME: String = "pluginMaven"
     }
 
     override fun apply(target: Project) {
@@ -51,6 +51,9 @@ public class PublishPlugin : Plugin<Project> {
             from(android.sourceSets["main"].java.srcDirs)
         }
 
+        // Pre-create publication to make it configurable
+        publishing.publications.create<MavenPublication>(PUBLICATION_NAME)
+
         // Because the components are created only during the afterEvaluate phase, you must
         // configure your publications using the afterEvaluate() lifecycle method.
         afterEvaluate {
@@ -61,7 +64,7 @@ public class PublishPlugin : Plugin<Project> {
             }
 
             publishing {
-                publications.create<MavenPublication>(PUBLICATION_NAME) {
+                publications.getByName<MavenPublication>(PUBLICATION_NAME) {
                     from(components["release"])
                     artifact(sourcesJar.get())
                 }

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -73,14 +73,20 @@ public class PublishPlugin : Plugin<Project> {
 
     private fun Project.configurePluginPublication(): String {
         @Suppress("UnstableApiUsage")
-        java.withSourcesJar()
+        java {
+            withSourcesJar()
+            withJavadocJar()
+        }
 
         return PLUGIN_PUBLICATION_NAME
     }
 
     private fun Project.configurePublication(): String {
         @Suppress("UnstableApiUsage")
-        java.withSourcesJar()
+        java {
+            withSourcesJar()
+            withJavadocJar()
+        }
 
         publishing {
             publications.create<MavenPublication>(PUBLICATION_NAME) {

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -31,7 +31,11 @@ public class PublishPlugin : Plugin<Project> {
                 val redmadrobot = redmadrobotExtension
 
                 publishing.publications.getByName<MavenPublication>(publicationName) {
-                    redmadrobot.publishing.configurePom(pom)
+                    pom {
+                        name.convention(project.name)
+                        description.convention(project.description)
+                        redmadrobot.publishing.configurePom(this)
+                    }
                 }
 
                 if (redmadrobot.publishing.signArtifacts) {

--- a/infrastructure/src/main/kotlin/extension/MavenPom.kt
+++ b/infrastructure/src/main/kotlin/extension/MavenPom.kt
@@ -1,0 +1,66 @@
+package com.redmadrobot.build.extension
+
+import org.gradle.api.publish.maven.*
+
+/** Adds [MIT License](https://opensource.org/licenses/mit-license.php) to publication. */
+public fun MavenPomLicenseSpec.mit() {
+    license {
+        name.set("MIT License")
+        url.set("https://opensource.org/licenses/mit-license.php")
+    }
+}
+
+private const val GITHUB_DOMAIN = "github.com"
+
+/**
+ * Configures `<url>`, `<issueManagement>` and `<scm>` with the given GitHub [projectName].
+ * ```
+ * pom {
+ *     setGitHubProject("RedMadRobot/gradle-infrastructure")
+ * }
+ * ```
+ */
+public fun MavenPom.setGitHubProject(projectName: String) {
+    val gitHubUrl = "https://$GITHUB_DOMAIN/$projectName"
+
+    url.set(gitHubUrl)
+
+    issueManagement {
+        url.set("$gitHubUrl/issues")
+        system.set("GitHub Issues")
+    }
+
+    scm {
+        url.set(gitHubUrl)
+        connection.set("scm:git:git://$GITHUB_DOMAIN/$projectName.git")
+        developerConnection.set("scm:git:ssh://git@$GITHUB_DOMAIN:$projectName.git")
+    }
+}
+
+/** Adds developer to publication. */
+public fun MavenPomDeveloperSpec.developer(
+    id: String,
+    name: String,
+    email: String,
+    action: MavenPomDeveloper.() -> Unit = {}
+) {
+    developer {
+        this.id.set(id)
+        this.name.set(name)
+        this.email.set(email)
+        action()
+    }
+}
+
+/** Adds contributor to publication. */
+public fun MavenPomContributorSpec.contributor(
+    name: String,
+    email: String,
+    action: MavenPomContributor.() -> Unit = {}
+) {
+    contributor {
+        this.name.set(name)
+        this.email.set(email)
+        action()
+    }
+}

--- a/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
+++ b/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
@@ -3,6 +3,7 @@ package com.redmadrobot.build.extension
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.gradle.kotlin.dsl.getByType
 
@@ -81,6 +82,16 @@ public class PublishingOptions internal constructor() {
 
     /** Use gpg-agent to sign artifacts. Has effect only if [signArtifacts] is true. */
     public var useGpgAgent: Boolean = true
+
+    internal var configurePom: MavenPom.() -> Unit = {}
+
+    /**
+     * Configures POM file for all modules.
+     * Place here only common configurations.
+     */
+    public fun pom(configure: MavenPom.() -> Unit) {
+        configurePom = configure
+    }
 }
 
 public class TestOptions internal constructor() {


### PR DESCRIPTION
Now you can configure common for all modules POM properties in `redmadrobot.publishing` extension.
There are extension-functions to cover common configuration use-cases.

```kotlin
redmadrobot {
    publishing {
        pom {
            // Configure <url>, <scm> and <issueManagement> tags for GitHub project by it's name
            setGitHubProject("RedMadRobot/gradle-infrastructure")
            
            licenses { 
                mit() // Add MIT license
            }
            
            developers {
                // Shorthand to add a developer
                developer(id = "jdoe", name = "John Dow", email = "john@doe.com")
            }
        }
    }
}
```

Use `publishing` extension in module build script to configure POM for this module.
Take publication name from `PUBLICATION_NAME` constant.

```kotlin
publishing {
    publications {
        getByName<MavenPublication>(PUBLICATION_NAME) {
            pom {
                // Configure POM here
            }
        }
    }
}

// or even shorter
publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
    pom {
        // Configure POM here
    }
}
```