### PR TITLE
Fix warnings as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Flag `warningsAsErrors` now should work.
+  It is enabled by default on CI.
+
 ## [0.8.2] (2021-03-30)
 
 ### JCenter only for exclusive content

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ redmadrobot {
 }
 ```
 
+### Warnings as errors
+
+By default, infrastructure plugins enable Kotlin compiler's option `allWarningsAsErrors` (`-Werror`) on CI.
+You can change it by defining the `warningsAsErrors` project property.
+
+[Read more about Gradle project properties][project-properties]
+
 ### Share sources between build types
 
 You can share sources between two build types.  
@@ -388,5 +395,6 @@ For major changes, please open an issue first to discuss what you would like to 
 [explicit-api]: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors
 [signing-plugin]: https://docs.gradle.org/current/userguide/signing_plugin.html
 [maven-publish]: https://docs.gradle.org/current/userguide/publishing_maven.html
+[project-properties]: https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties
 
 [jcenter-end]: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

--- a/infrastructure/src/main/kotlin/Kotlin.kt
+++ b/infrastructure/src/main/kotlin/Kotlin.kt
@@ -1,19 +1,27 @@
 package com.redmadrobot.build
 
 import com.redmadrobot.build.extension.TestOptions
+import com.redmadrobot.build.extension.isRunningOnCi
 import com.redmadrobot.build.extension.redmadrobotExtension
+import com.redmadrobot.build.internal.findBooleanProperty
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.kotlin
 
 internal fun Project.configureKotlin() {
+    val warningsAsErrors = getWarningsAsErrorsProperty()
     kotlinCompile {
         kotlinOptions {
             jvmTarget = "1.8"
-            allWarningsAsErrors = findProperty("warningsAsErrors") == true
+            allWarningsAsErrors = warningsAsErrors
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         }
     }
+}
+
+/** Use property value if it exists or fallback to true if running on CI. */
+private fun Project.getWarningsAsErrorsProperty(): Boolean {
+    return findBooleanProperty("warningsAsErrors") ?: isRunningOnCi
 }
 
 internal fun Project.configureKotlinTest() {

--- a/infrastructure/src/main/kotlin/internal/Properties.kt
+++ b/infrastructure/src/main/kotlin/internal/Properties.kt
@@ -1,0 +1,7 @@
+package com.redmadrobot.build.internal
+
+import org.gradle.api.Project
+
+internal fun Project.findBooleanProperty(propertyName: String): Boolean? {
+    return (project.findProperty(propertyName) as? String)?.toBoolean()
+}

--- a/samples/android-application-multi/app/build.gradle.kts
+++ b/samples/android-application-multi/app/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("com.google.android.material:material:1.3.0")
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.3.4")
-    implementation("androidx.navigation:navigation-ui-ktx:2.3.4")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
+    implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")

--- a/samples/android-application/app/build.gradle.kts
+++ b/samples/android-application/app/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("com.google.android.material:material:1.3.0")
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.3.4")
-    implementation("androidx.navigation:navigation-ui-ktx:2.3.4")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
+    implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")


### PR DESCRIPTION
Flag `warningsAsErrors` now should work.
It is enabled by default on CI.