### PR TITLE
Gradle 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Changes
+
+- Updated Gradle 6.8.3 -> 7.0
+- Completely removed `jcenter` from repositories (#36)
+
 ### Fixed
 
 - Flag `warningsAsErrors` now should work.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -42,13 +42,6 @@ gradlePlugin {
 repositories {
     mavenCentral()
     google()
-    jcenter {
-        content {
-            // TODO #36 Remove this after update to new AGP version
-            //  See: https://youtrack.jetbrains.com/issue/IDEA-261387
-            includeModule("org.jetbrains.trove4j", "trove4j")
-        }
-    }
 }
 
 dependencies {

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -10,10 +10,6 @@ group = "com.redmadrobot.build"
 description = "Small plugins to reduce boilerplate in Gradle build scripts."
 version = "0.9-SNAPSHOT"
 
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-
 gradlePlugin {
     plugins {
         register("root-project") {

--- a/infrastructure/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure/src/main/kotlin/BaseAndroidPlugin.kt
@@ -70,13 +70,6 @@ private fun Project.configureAndroid() = android<BaseExtension> {
 private fun Project.configureRepositories() {
     repositories {
         mavenCentral()
-        jcenter {
-            content {
-                // TODO #36 Remove this after update to new AGP version
-                //  See: https://youtrack.jetbrains.com/issue/IDEA-261387
-                includeModule("org.jetbrains.trove4j", "trove4j")
-            }
-        }
         google()
     }
 }

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -22,15 +22,21 @@ public class DetektPlugin : Plugin<Project> {
     }
 
     private fun Project.configureDependencies() {
-        repositories {
-            mavenCentral()
-            jcenter {
-                content {
-                    // TODO #36 Remove this after migration of kotlinx-html to Maven Central
-                    //  See: https://github.com/Kotlin/kotlinx.html/issues/173
-                    includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+        // TODO: Remove after update to Detekt 1.17.0
+        configurations.all {
+            resolutionStrategy.eachDependency {
+                if (requested.group == "org.jetbrains.kotlinx" &&
+                    requested.name == "kotlinx-html-jvm" &&
+                    requested.version == "0.7.2"
+                ) {
+                    useVersion("0.7.3")
+                    because("This version is published to Maven Central")
                 }
             }
+        }
+
+        repositories {
+            mavenCentral()
         }
 
         dependencies {

--- a/samples/android-application-multi/build.gradle.kts
+++ b/samples/android-application-multi/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("redmadrobot.root-project") version "0.8.2"
+    id("redmadrobot.root-project") version "0.9-SNAPSHOT"
 }
 
 // Common configurations for all modules

--- a/samples/android-application-multi/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/android-application-multi/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/android-application/build.gradle.kts
+++ b/samples/android-application/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("redmadrobot.root-project") version "0.8.2"
+    id("redmadrobot.root-project") version "0.9-SNAPSHOT"
 }

--- a/samples/android-application/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/android-application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Updated Gradle 6.8.3 -> 7.0
- Completely removed `jcenter` from repositories (#36)