### PR TITLE
Kotlin update to 1.5.10 and don't apply dependencies by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,42 @@
 ## [Unreleased]
 
+### Plugins no more add Kotlin dependencies
+
+> **Breaking change!**
+
+Previously plugins `kotlin-library`, `android-library` and `application` used to add `kotlin-stdlib-jdk8` and `kotlin-test` dependencies by default.
+It was a problem because:
+
+1. Sometimes you don't want to add these dependencies
+2. Or want to add it with different configuration (for example `compileOnly` instead of `implementation`)
+
+**gradle-infrastructure** should add only options valid for all our projects or default options that can be changed if needed.
+Default applied dependencies can't be removed if needed, so they should not be applied by default.
+
+#### Another problem is `redmadrobot.kotlinVersion`.
+
+> Option `redmadrobot.kotlinVersion` is deprecated since this version and will not take any effect.
+
+We've introduced this option to make it possible to change version of default kotlin dependencies.
+This option affects only dependencies added by gradle-infrastructure, not all Kotlin dependencies, and it is confusing.
+Moreover, this version does not affect Kotlin Gradle Plugin because it uses version specified in gradle-infrastructure at compilation time.
+
+A more convenient way to align the Kotlin version for all dependencies including transitive ones is to use `kotlin-bom`:
+
+```kotlin
+dependencies {
+    // Align versions of all Kotlin components 
+    implementation(platform(kotlin("bom", version = "1.5.10")))
+
+    // Now you can add Kotlin components without version
+    implementation(kotlin("stdlib-jdk8"))
+    testImplementation(kotlin("test-junit5"))
+}
+```
+
 ### Added
 
-- Specified location for Detekt baseline: `$configsDir/detekt/baseline.xml`
+- Specified default location for Detekt baseline: `$configsDir/detekt/baseline.xml`
 - Added the ability to check the Detekt only on changed files ([#40](https://github.com/RedMadRobot/gradle-infrastructure/issues/40)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Added
 
-- Memory leak fix for Kotlin 1.5.0 until 1.5.10 released ([KT-46368](https://youtrack.jetbrains.com/issue/KT-46368))
 - Specified location for Detekt baseline: `$configsDir/detekt/baseline.xml`
 - Added the ability to check the Detekt only on changed files ([#40](https://github.com/RedMadRobot/gradle-infrastructure/issues/40)).
 
@@ -12,7 +11,7 @@
 
 ### Dependencies
 
-- Update Kotlin 1.4.32 -> 1.5.0
+- Update Kotlin 1.4.32 -> 1.5.10
 - Update AGP 4.1.3 -> 4.2.1
 - Update Detekt 1.16.0 -> 1.17.1
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,23 @@ redmadrobot {
 }
 ```
 
+### Align version of all Kotlin libraries
+
+> It is not a part of **gradle-infrastructure** but it is important to know.
+
+To align the Kotlin version for all dependencies including transitive ones, use `kotlin-bom`:
+
+```kotlin
+dependencies {
+    // Align versions of all Kotlin components 
+    implementation(platform(kotlin("bom", version = "1.5.10")))
+
+    // Now you can add Kotlin components without version
+    implementation(kotlin("stdlib-jdk8"))
+    testImplementation(kotlin("test-junit5"))
+}
+```
+
 ### Warnings as errors
 
 By default, infrastructure plugins enable Kotlin compiler's option `allWarningsAsErrors` (`-Werror`) on CI.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 apply(plugin = "redmadrobot.detekt")
 
 redmadrobot {
-    kotlinVersion = "1.5.0"
+    kotlinVersion = "1.5.10"
 
     publishing {
         signArtifacts = !isRunningOnCi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.redmadrobot.build.extension.*
+import com.redmadrobot.build.kotlinCompile
 
 plugins {
     id("redmadrobot.root-project") version "0.9"
@@ -10,8 +11,6 @@ plugins {
 apply(plugin = "redmadrobot.detekt")
 
 redmadrobot {
-    kotlinVersion = "1.5.10"
-
     publishing {
         signArtifacts = !isRunningOnCi
 
@@ -39,6 +38,14 @@ subprojects {
 
     group = "com.redmadrobot.build"
     version = "0.10-SNAPSHOT"
+
+    // Keep gradle-infrastructure compatible with older versions of Gradle.
+    kotlinCompile {
+        kotlinOptions {
+            apiVersion = "1.3"
+            languageVersion = "1.3"
+        }
+    }
 
     publishing {
         repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ redmadrobot {
 
             developers {
                 developer(id = "osipxd", name = "Osip Fatkullin", email = "o.fatkullin@redmadrobot.com")
+                developer(id = "rwqwr", name = "Roman Ivanov", email = "r.ivanov@redmadrobot.com")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,3 @@ kotlin.code.style=official
 
 # Disable Android Studio version check to be able to use Intellij IDEA.
 android.injected.studio.version.check=false
-
-# TODO: Remove after update to Kotlin 1.5.10
-#  Issue: https://youtrack.jetbrains.com/issue/KT-41142
-warningsAsErrors=false

--- a/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -3,7 +3,6 @@ package com.redmadrobot.build
 import com.android.build.gradle.AppExtension
 import com.redmadrobot.build.extension.RedmadrobotExtension
 import com.redmadrobot.build.internal.android
-import com.redmadrobot.build.internal.configureKotlinDependencies
 import org.gradle.api.Project
 
 public class AndroidApplicationPlugin : BaseAndroidPlugin() {
@@ -11,7 +10,6 @@ public class AndroidApplicationPlugin : BaseAndroidPlugin() {
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.application")
 
-        configureKotlinDependencies(redmadrobotExtension.kotlinVersion, "implementation")
         configureApp(redmadrobotExtension)
     }
 }

--- a/infrastructure-android/src/main/kotlin/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidLibraryPlugin.kt
@@ -2,7 +2,6 @@ package com.redmadrobot.build
 
 import com.android.build.gradle.LibraryExtension
 import com.redmadrobot.build.internal.android
-import com.redmadrobot.build.internal.configureKotlinDependencies
 import com.redmadrobot.build.internal.kotlin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -23,9 +22,7 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
             }
         }
 
-        configureKotlinDependencies(redmadrobotExtension.kotlinVersion)
-
-        // Enable Explicit API by default
+        // Enable Explicit API mode for libraries by default
         if (kotlin.explicitApi == null) kotlin.explicitApi()
         afterEvaluate {
             configureExplicitApi(kotlin.explicitApi)

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -5,7 +5,6 @@ import com.redmadrobot.build.extension.AndroidOptions
 import com.redmadrobot.build.extension.android
 import com.redmadrobot.build.internal.android
 import com.redmadrobot.build.internal.configureKotlin
-import com.redmadrobot.build.internal.configureKotlinTestDependencies
 import com.redmadrobot.build.internal.setTestOptions
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
@@ -29,7 +28,6 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
         configureKotlin()
         configureAndroid(redmadrobotExtension.android)
         configureRepositories()
-        configureKotlinTestDependencies(redmadrobotExtension.kotlinVersion, redmadrobotExtension.android.test)
     }
 }
 

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -26,10 +26,7 @@ repositories {
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.5.0"))
+    api(kotlin("gradle-plugin", version = "1.5.10"))
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1")
-    // TODO: Remove after Kotlin 1.5.10 release
-    //  https://youtrack.jetbrains.com/issue/KT-46368
-    implementation("dev.zacsweers:kgp-150-leak-patcher:1.1.0")
     implementation("org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r")
 }

--- a/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
@@ -19,13 +19,12 @@ public class KotlinLibraryPlugin : InfrastructurePlugin() {
             sourceCompatibility = JavaVersion.VERSION_1_8
         }
 
+        // Enable Explicit API mode for libraries by default
         kotlin.explicitApi()
 
         val extension = redmadrobotExtension
         configureKotlin()
-        configureKotlinDependencies(extension.kotlinVersion)
         configureKotlinTest(extension.test)
-        configureKotlinTestDependencies(extension.kotlinVersion, extension.test)
         configureRepositories()
     }
 }

--- a/infrastructure/src/main/kotlin/RootProjectPlugin.kt
+++ b/infrastructure/src/main/kotlin/RootProjectPlugin.kt
@@ -3,7 +3,6 @@ package com.redmadrobot.build
 import com.redmadrobot.build.extension.RedmadrobotExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 
 public class RootProjectPlugin : Plugin<Project> {
@@ -12,9 +11,6 @@ public class RootProjectPlugin : Plugin<Project> {
         check(target.rootProject == target) { "This plugin can be applied only to the root project." }
 
         target.configureExtension()
-        // TODO: Remove after Kotlin 1.5.10 release
-        //  https://youtrack.jetbrains.com/issue/KT-46368
-        target.apply(plugin = "dev.zacsweers.kgp-150-leak-patcher")
     }
 
     private fun Project.configureExtension() {

--- a/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
+++ b/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
@@ -42,7 +42,7 @@ public open class RedmadrobotExtension(objects: ObjectFactory) {
     }
 
     /** Kotlin version that should be used for all projects. */
-    public var kotlinVersion: String = "1.5.0"
+    public var kotlinVersion: String = "1.5.10"
 
     /** Directory where stored configs for static analyzers. */
     public val configsDir: DirectoryProperty = objects.directoryProperty()

--- a/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
+++ b/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
@@ -42,7 +42,15 @@ public open class RedmadrobotExtension(objects: ObjectFactory) {
     }
 
     /** Kotlin version that should be used for all projects. */
-    public var kotlinVersion: String = "1.5.10"
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "This option have not effect anymore. " +
+            "Remove it and use `kotlin-bom` to align Kotlin version across all dependencies.",
+    )
+    @Suppress("unused_parameter")
+    public var kotlinVersion: String
+        set(value) = error("You should not use this.")
+        get() = error("You should not use this.")
 
     /** Directory where stored configs for static analyzers. */
     public val configsDir: DirectoryProperty = objects.directoryProperty()

--- a/infrastructure/src/main/kotlin/internal/Configurations.kt
+++ b/infrastructure/src/main/kotlin/internal/Configurations.kt
@@ -2,6 +2,4 @@
 
 package com.redmadrobot.build.internal
 
-internal const val api: String = "api"
-internal const val testImplementation: String = "testImplementation"
 internal const val detektPlugins: String = "detektPlugins"

--- a/infrastructure/src/main/kotlin/internal/Kotlin.kt
+++ b/infrastructure/src/main/kotlin/internal/Kotlin.kt
@@ -4,8 +4,6 @@ import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.extension.isRunningOnCi
 import com.redmadrobot.build.kotlinCompile
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.kotlin
 
 public fun InfrastructurePlugin.configureKotlin() {
     val warningsAsErrors = project.getWarningsAsErrorsProperty()
@@ -21,10 +19,4 @@ public fun InfrastructurePlugin.configureKotlin() {
 /** Use property value if it exists or fallback to true if running on CI. */
 private fun Project.getWarningsAsErrorsProperty(): Boolean {
     return findBooleanProperty("warningsAsErrors") ?: isRunningOnCi
-}
-
-public fun InfrastructurePlugin.configureKotlinDependencies(kotlinVersion: String, configuration: String = api) {
-    project.dependencies {
-        configuration(kotlin("stdlib-jdk8", version = kotlinVersion))
-    }
 }

--- a/infrastructure/src/main/kotlin/internal/Test.kt
+++ b/infrastructure/src/main/kotlin/internal/Test.kt
@@ -1,23 +1,7 @@
 package com.redmadrobot.build.internal
 
-import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.extension.TestOptions
 import org.gradle.api.tasks.testing.Test
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.kotlin
-
-public fun InfrastructurePlugin.configureKotlinTestDependencies(kotlinVersion: String, testOptions: TestOptions) {
-    project.dependencies {
-        val kotlinJunitModule = if (testOptions.useJunitPlatform) {
-            "test-junit5"
-        } else {
-            "test-junit"
-        }
-
-        testImplementation(kotlin("test", version = kotlinVersion))
-        testImplementation(kotlin(kotlinJunitModule, version = kotlinVersion))
-    }
-}
 
 public fun Test.setTestOptions(testOptions: TestOptions) {
     if (testOptions.useJunitPlatform) {

--- a/samples/android-application-multi/app/build.gradle.kts
+++ b/samples/android-application-multi/app/build.gradle.kts
@@ -16,7 +16,11 @@ android {
 }
 
 dependencies {
-    // Kotlin already added as dependency to the project
+    // Algin Kotlin version across all dependencies
+    implementation(platform(kotlin("bom", version = "1.5.10")))
+
+    // Kotlin components can be added without version specifying
+    implementation(kotlin("stdlib-jdk8"))
 
     implementation(project(":module1"))
     implementation(project(":module2"))
@@ -27,6 +31,7 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
 
+    testImplementation(kotlin("test-junit5"))
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")

--- a/samples/android-application-multi/module1/build.gradle.kts
+++ b/samples/android-application-multi/module1/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    // Kotlin already added as dependency to the project
+    implementation(kotlin("stdlib-jdk8"))
     // ...
     // Dependencies for the module here
     // ...

--- a/samples/android-application-multi/module2/build.gradle.kts
+++ b/samples/android-application-multi/module2/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 kotlin.explicitApi = null
 
 dependencies {
-    // Kotlin already added as dependency to the project
+    implementation(kotlin("stdlib-jdk8"))
     // ...
     // Dependencies for the module here
     // ...

--- a/samples/android-application/app/build.gradle.kts
+++ b/samples/android-application/app/build.gradle.kts
@@ -26,7 +26,11 @@ android {
 }
 
 dependencies {
-    // Kotlin already added as dependency to the project
+    // Algin Kotlin version across all dependencies
+    implementation(platform(kotlin("bom", version = "1.5.10")))
+
+    // Kotlin components can be added without version specifying
+    implementation(kotlin("stdlib-jdk8"))
 
     implementation("androidx.appcompat:appcompat:1.3.0")
     implementation("com.google.android.material:material:1.3.0")
@@ -34,7 +38,8 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
 
+    testImplementation(kotlin("test-junit5"))
     androidTestImplementation("androidx.test.ext:junit:1.1.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
 }


### PR DESCRIPTION
### Plugins no more add Kotlin dependencies

> **Breaking change!**

Previously plugins `kotlin-library`, `android-library` and `application` used to add `kotlin-stdlib-jdk8` and `kotlin-test` dependencies by default.
It was a problem because:

1. Sometimes you don't want to add these dependencies
2. Or want to add it with different configuration (for example `compileOnly` instead of `implementation`)

**gradle-infrastructure** should add only options valid for all our projects or default options that can be changed if needed.
Default applied dependencies can't be removed if needed, so they should not be applied by default.

#### Another problem is `redmadrobot.kotlinVersion`.

> Option `redmadrobot.kotlinVersion` is deprecated since this version and will not take any effect.

We've introduced this option to make it possible to change version of default kotlin dependencies.
This option affects only dependencies added by gradle-infrastructure, not all Kotlin dependencies, and it is confusing.
Moreover, this version does not affect Kotlin Gradle Plugin because it uses version specified in gradle-infrastructure at compilation time.

A more convenient way to align the Kotlin version for all dependencies including transitive ones is to use `kotlin-bom`:

```kotlin
dependencies {
    // Align versions of all Kotlin components 
    implementation(platform(kotlin("bom", version = "1.5.10")))

    // Now you can add Kotlin components without version
    implementation(kotlin("stdlib-jdk8"))
    testImplementation(kotlin("test-junit5"))
}
```