### PR TITLE
publish: Improve publication and signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ dependencies {
 ### Changed
 
 - Update Gradle 7.0 -> 7.0.2
+- Flag `publishing.signArtifacts` now affects all artifacts not only the main one
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ dependencies {
 ### Fixed
 
 - Publication not configured when `redmadrobot.publish` applied before other plugins
+- Look at flag `gradlePlugin.isAutomatedPublishing` when configuring gradle plugin publication
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ dependencies {
 - Update Gradle 7.0 -> 7.0.2
 - Flag `publishing.signArtifacts` now affects all artifacts not only the main one
 
+### Fixed
+
+- Publication not configured when `redmadrobot.publish` applied before other plugins
+
 ### Dependencies
 
 - Update Kotlin 1.4.32 -> 1.5.10

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# infrastructure <GitHub path="RedMadRobot/gradle-infrastructure"/>
+# Gradle Infrastructure <GitHub path="RedMadRobot/gradle-infrastructure"/>
 [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.build/infrastructure?style=flat-square)][mavenCentral] [![Build Status](https://img.shields.io/github/workflow/status/RedMadRobot/gradle-infrastructure/CI/main?style=flat-square)][ci] [![License](https://img.shields.io/github/license/RedMadRobot/gradle-infrastructure?style=flat-square)][license]
 
 Small plugins to reduce boilerplate in Gradle build scripts.

--- a/infrastructure-android/src/main/kotlin/AndroidPublishPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidPublishPlugin.kt
@@ -6,37 +6,33 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 
 public class AndroidPublishPlugin : PublishPlugin() {
 
     override fun Project.configureAndroidPublication(): String {
+        checkVersionSpecified()
+
         val sourcesJar = tasks.register<Jar>("sourcesJar") {
             archiveClassifier.set("sources")
             from(android.sourceSets["main"].java.srcDirs)
         }
 
-        // Pre-create publication to make it configurable on signing configuration
-        publishing.publications.create<MavenPublication>(PUBLICATION_NAME)
-
-        // Because the components are created only during the afterEvaluate phase, you must
-        // configure your publications using the afterEvaluate() lifecycle method.
-        afterEvaluate {
-            if (version == Project.DEFAULT_VERSION) {
-                version = checkNotNull(android.defaultConfig.versionName) {
-                    "You should specify either project 'version' or 'android.versionName' for publication."
-                }
-            }
-
-            publishing {
-                publications.getByName<MavenPublication>(PUBLICATION_NAME) {
-                    from(components[BUILD_TYPE_RELEASE])
-                    artifact(sourcesJar.get())
-                }
+        publishing {
+            publications.create<MavenPublication>(PUBLICATION_NAME) {
+                from(components[BUILD_TYPE_RELEASE])
+                artifact(sourcesJar.get())
             }
         }
 
         return PUBLICATION_NAME
+    }
+
+    private fun Project.checkVersionSpecified() {
+        if (version == Project.DEFAULT_VERSION) {
+            version = checkNotNull(android.defaultConfig.versionName) {
+                "You should specify either project 'version' or 'android.versionName' for publication."
+            }
+        }
     }
 }

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.*
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
@@ -23,7 +24,7 @@ public open class PublishPlugin : InfrastructurePlugin() {
         afterEvaluate {
             val publicationName = when {
                 plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
-                plugins.hasPlugin("java-gradle-plugin") -> configurePluginPublication()
+                plugins.hasPlugin("java-gradle-plugin") && isPluginAutomatedPublishing -> configurePluginPublication()
                 else -> configurePublication()
             }
 
@@ -97,6 +98,9 @@ public open class PublishPlugin : InfrastructurePlugin() {
 
     protected val publishing: PublishingExtension
         get() = project.extensions.getByName<PublishingExtension>("publishing")
+
+    private val isPluginAutomatedPublishing: Boolean
+        get() = project.extensions.getByType<GradlePluginDevelopmentExtension>().isAutomatedPublishing
 
     protected fun publishing(configure: PublishingExtension.() -> Unit) {
         project.extensions.configure("publishing", configure)

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -16,28 +16,17 @@ public open class PublishPlugin : InfrastructurePlugin() {
         public const val PLUGIN_PUBLICATION_NAME: String = "pluginMaven"
     }
 
-    protected val publishing: PublishingExtension
-        get() = project.extensions.getByName<PublishingExtension>("publishing")
-
-    protected fun publishing(configure: PublishingExtension.() -> Unit) {
-        project.extensions.configure("publishing", configure)
-    }
-
-    private fun signing(configure: SigningExtension.() -> Unit) {
-        project.extensions.configure("signing", configure)
-    }
-
     override fun Project.configure() {
         apply(plugin = "maven-publish")
 
-        val publicationName = when {
-            plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
-            plugins.hasPlugin("java-gradle-plugin") -> configurePluginPublication()
-            else -> configurePublication()
-        }
-
         // Do it after project evaluate to be able to access publications created later
         afterEvaluate {
+            val publicationName = when {
+                plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
+                plugins.hasPlugin("java-gradle-plugin") -> configurePluginPublication()
+                else -> configurePublication()
+            }
+
             val options = redmadrobotExtension.publishing
 
             publishing.publications.getByName<MavenPublication>(publicationName) {
@@ -102,5 +91,18 @@ public open class PublishPlugin : InfrastructurePlugin() {
         tasks.withType<Sign>().configureEach {
             onlyIf { isReleaseVersion }
         }
+    }
+
+    // Accessors
+
+    protected val publishing: PublishingExtension
+        get() = project.extensions.getByName<PublishingExtension>("publishing")
+
+    protected fun publishing(configure: PublishingExtension.() -> Unit) {
+        project.extensions.configure("publishing", configure)
+    }
+
+    private fun signing(configure: SigningExtension.() -> Unit) {
+        project.extensions.configure("signing", configure)
     }
 }

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -49,7 +49,7 @@ public open class PublishPlugin : InfrastructurePlugin() {
             }
 
             if (options.signArtifacts) {
-                configureSigning(publicationName, options.useGpgAgent)
+                configureSigning(options.useGpgAgent)
             }
         }
     }
@@ -91,12 +91,12 @@ public open class PublishPlugin : InfrastructurePlugin() {
         return PUBLICATION_NAME
     }
 
-    private fun Project.configureSigning(publicationName: String, useGpgAgent: Boolean) {
+    private fun Project.configureSigning(useGpgAgent: Boolean) {
         apply(plugin = "signing")
 
         signing {
             if (useGpgAgent) useGpgCmd()
-            sign(publishing.publications[publicationName])
+            sign(publishing.publications)
         }
 
         tasks.withType<Sign>().configureEach {


### PR DESCRIPTION
### Changed

- Flag `publishing.signArtifacts` now affects all artifacts not only the main one

### Fixed

- Publication not configured when `redmadrobot.publish` applied before other plugins
- Look at flag `gradlePlugin.isAutomatedPublishing` when configuring gradle plugin publication