### PR TITLE
version 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.11] (2021-07-06)
+
 ### Dependencies
 
 - Kotlin Gradle Plugin 1.5.10 -> 1.5.20
@@ -9,11 +11,11 @@
 
 - Added ability to configure `compileSdk` separately from `targetSdk`
 - Added ability to configure `buildToolsVersion` for all android modules
-- Added KDoc comments to the all plugins
 
 ### Housekeeping
 
 - Update Gradle 7.0.2 -> 7.1.1
+- Added KDoc comments to the all plugins
 
 ## [0.10] (2021-05-31)
 
@@ -298,7 +300,8 @@ Pull request: #35
 - Update dependencies in samples
 - Added CHANGELOG.md :)
 
-[unreleased]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.10...main
+[unreleased]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.11...main
+[0.11]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.10...v0.11
 [0.10]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.9...v0.10
 [0.9]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.8.2...v0.9
 [0.8.2]: https://github.com/RedMadRobot/gradle-infrastructure/compare/v0.8.1..v0.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 - Kotlin Gradle Plugin 1.5.10 -> 1.5.20
 - JGit 5.11.0 -> 5.12.0
 
-### Changed
+### Added
+
+- Added ability to configure `compileSdk` separately from `targetSdk`
+- Added ability to configure `buildToolsVersion` for all android modules
+- Added KDoc comments to the all plugins
+
+### Housekeeping
 
 - Update Gradle 7.0.2 -> 7.1.1
 
@@ -45,7 +51,7 @@ Default applied dependencies can't be removed if needed, so they should not be a
 
 #### Another problem is `redmadrobot.kotlinVersion`.
 
-> Option `redmadrobot.kotlinVersion` is deprecated since this version and will not take any effect.
+> Option `redmadrobot.kotlinVersion` is deprecated and will not take any effect.
 
 We've introduced this option to make it possible to change version of default kotlin dependencies.
 This option affects only dependencies added by gradle-infrastructure, not all Kotlin dependencies, and it is confusing.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pluginManagement {
 Apply `redmadrobot.root-project` to your root project:
 ```kotlin
 plugins {
-    id("redmadrobot.root-project") version "0.10"
+    id("redmadrobot.root-project") version "0.11"
 }
 ```
 
@@ -154,7 +154,7 @@ redmadrobot {
             
             developers {
                 // Shorthand to add a developer
-                developer(id = "jdoe", name = "John Dow", email = "john@doe.com")
+                developer(id = "j.doe", name = "John Doe", email = "john@doe.com")
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -265,6 +265,19 @@ dependencies {
 }
 ```
 
+Another way is using `kotlin.coreLibrariesVersion` property:
+
+```kotlin
+// Set version for all Kotlin components
+kotlin.coreLibrariesVersion = "1.5.10"
+
+dependencies {
+    // Now you can add Kotlin components without version
+    implementation(kotlin("stdlib-jdk8"))
+    testImplementation(kotlin("test-junit5"))
+}
+```
+
 ### Warnings as errors
 
 By default, infrastructure plugins enable Kotlin compiler's option `allWarningsAsErrors` (`-Werror`) on CI.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ subprojects {
     }
 
     group = "com.redmadrobot.build"
-    version = "0.11-SNAPSHOT"
+    version = "0.11"
 
     // Keep gradle-infrastructure compatible with older versions of Gradle.
     kotlinCompile {

--- a/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -9,6 +9,12 @@ import com.redmadrobot.build.extension.RedmadrobotExtension
 import com.redmadrobot.build.internal.android
 import org.gradle.api.Project
 
+/**
+ * Plugin with default configurations for Android application project.
+ * Should be applied in place of `com.android.application`.
+ *
+ * Tied to `redmadrobot.application` plugin ID.
+ */
 public class AndroidApplicationPlugin : BaseAndroidPlugin() {
 
     override fun Project.configure() {

--- a/infrastructure-android/src/main/kotlin/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidLibraryPlugin.kt
@@ -9,12 +9,19 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 private const val ARG_EXPLICIT_API = "-Xexplicit-api"
 
+/**
+ * Plugin with default configurations for Android library project.
+ * Should be applied in place of `com.android.library`.
+ *
+ * Tied to `redmadrobot.android-library` plugin ID.
+ */
 public class AndroidLibraryPlugin : BaseAndroidPlugin() {
 
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.library")
 
         android<LibraryExtension> {
+            @Suppress("UnstableApiUsage")
             buildFeatures {
                 buildConfig = false
                 resValues = false

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -33,6 +33,7 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
 
 private fun Project.configureAndroid(options: AndroidOptions) = android<BaseExtension> {
     compileSdkVersion(options.compileSdk.get())
+    options.buildToolsVersion.orNull?.let(::buildToolsVersion)
 
     defaultConfig {
         minSdkVersion(options.minSdk.get())

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -32,7 +32,8 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
 }
 
 private fun Project.configureAndroid(options: AndroidOptions) = android<BaseExtension> {
-    compileSdkVersion(options.targetSdk.get())
+    compileSdkVersion(options.compileSdk.get())
+
     defaultConfig {
         minSdkVersion(options.minSdk.get())
         targetSdkVersion(options.targetSdk.get())

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -12,6 +12,11 @@ import org.gradle.kotlin.dsl.android
 import org.gradle.kotlin.dsl.repositories
 import java.io.File
 
+/**
+ * Base plugin with common configurations for both application and library modules.
+ * @see AndroidLibraryPlugin
+ * @see AndroidApplicationPlugin
+ */
 public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
 
     /** Should be called from [configure] in implementation. */
@@ -49,6 +54,7 @@ private fun Project.configureAndroid(options: AndroidOptions) = android<BaseExte
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    @Suppress("UnstableApiUsage")
     with(buildFeatures) {
         aidl = false
         renderScript = false

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
@@ -18,11 +18,18 @@ public fun RedmadrobotExtension.android(configure: AndroidOptions.() -> Unit) {
 
 public interface AndroidOptions : TestOptionsSpec {
 
-    /** Minimal Android SDK that will be applied to all android modules. */
+    /** Minimal Android SDK to use across all android modules. */
     public val minSdk: Property<Int>
 
-    /** Target Android SDK that will be applied to all android modules. Also determines compile SDK. */
+    /** Target Android SDK to use across all android modules. */
     public val targetSdk: Property<Int>
+
+    /**
+     * Compile Android SDK to use across all android modules.
+     * Format: `android-XX` where `XX` is required API level.
+     * Uses [targetSdk] as API level if not configured.
+     */
+    public val compileSdk: Property<String>
 
     public companion object {
         internal const val DEFAULT_MIN_API = 21

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
@@ -31,6 +31,12 @@ public interface AndroidOptions : TestOptionsSpec {
      */
     public val compileSdk: Property<String>
 
+    /**
+     * Build Tools version to use across all android modules.
+     * Uses default version for current Android Gradle Plugin if not configured.
+     */
+    public val buildToolsVersion: Property<String>
+
     public companion object {
         internal const val DEFAULT_MIN_API = 21
         internal const val DEFAULT_TARGET_API = 30

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
@@ -20,5 +20,8 @@ internal abstract class AndroidOptionsImpl @Inject constructor(objects: ObjectFa
         targetSdk
             .convention(AndroidOptions.DEFAULT_TARGET_API)
             .finalizeValueOnRead()
+        compileSdk
+            .convention(targetSdk.map { "android-$it" })
+            .finalizeValueOnRead()
     }
 }

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
@@ -23,5 +23,7 @@ internal abstract class AndroidOptionsImpl @Inject constructor(objects: ObjectFa
         compileSdk
             .convention(targetSdk.map { "android-$it" })
             .finalizeValueOnRead()
+        buildToolsVersion
+            .finalizeValueOnRead()
     }
 }

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -13,6 +13,12 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.repositories
 import java.io.File
 
+/**
+ * Plugin with common configurations for detekt.
+ * Should be applied to root project only.
+ *
+ * Tied to `redmadrobot.detekt` plugin ID.
+ */
 public class DetektPlugin : InfrastructurePlugin() {
 
     override fun Project.configure() {

--- a/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
@@ -1,7 +1,10 @@
 package com.redmadrobot.build
 
 import com.redmadrobot.build.extension.TestOptions
-import com.redmadrobot.build.internal.*
+import com.redmadrobot.build.internal.configureKotlin
+import com.redmadrobot.build.internal.java
+import com.redmadrobot.build.internal.kotlin
+import com.redmadrobot.build.internal.setTestOptions
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
@@ -9,6 +12,12 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 
+/**
+ * Plugin with default configurations for Kotlin library project.
+ * Should be applied in place of `kotlin` plugin.
+ *
+ * Tied to `redmadrobot.kotlin-library` plugin ID.
+ */
 public class KotlinLibraryPlugin : InfrastructurePlugin() {
 
     override fun Project.configure() {

--- a/infrastructure/src/main/kotlin/PublishPlugin.kt
+++ b/infrastructure/src/main/kotlin/PublishPlugin.kt
@@ -11,6 +11,11 @@ import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
+/**
+ * Plugin with configurations for publication.
+ *
+ * Tied to `redmadrobot.publish` plugin ID.
+ */
 public open class PublishPlugin : InfrastructurePlugin() {
 
     public companion object {

--- a/infrastructure/src/main/kotlin/RootProjectPlugin.kt
+++ b/infrastructure/src/main/kotlin/RootProjectPlugin.kt
@@ -7,6 +7,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
 
+/**
+ * This plugin adds extension [RedmadrobotExtension] to the project.
+ * Can be applied only to the root project.
+ *
+ * Tied to `redmadrobot.root-project` plugin ID.
+ *
+ * @see RedmadrobotExtension
+ */
 public class RootProjectPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {

--- a/samples/android-application-multi/build.gradle.kts
+++ b/samples/android-application-multi/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("redmadrobot.root-project") version "0.11-SNAPSHOT"
+    id("redmadrobot.root-project") version "0.11"
 }
 
 // Common configurations for all modules

--- a/samples/android-application/build.gradle.kts
+++ b/samples/android-application/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("redmadrobot.root-project") version "0.11-SNAPSHOT"
+    id("redmadrobot.root-project") version "0.11"
 }


### PR DESCRIPTION
### Dependencies

- Kotlin Gradle Plugin 1.5.10 -> 1.5.20
- JGit 5.11.0 -> 5.12.0

### Added

- Added ability to configure `compileSdk` separately from `targetSdk`
- Added ability to configure `buildToolsVersion` for all android modules

### Housekeeping

- Update Gradle 7.0.2 -> 7.1.1
- Added KDoc comments to the all plugins