### PR TITLE
Root project anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Added
 
+- Plugin `redmadrobot.root-project` now can be applied to any project that should be considered as "root" project for gradle-infrastructure.
+  It may be useful for projects where you need to apply gradle-infrastructure only to particular projects.
 - Added Detekt tasks `detekt[Variant]All` with type resolution
 - Added the `detektBaselineAll` task to create a baseline file for Detekt rules.
 - Added `detektBaseline[Variant]All` tasks to create a baseline file for Detekt rules with type resolution.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pluginManagement {
 }
 ```
 
-Apply `redmadrobot.root-project` to your root project:
+Apply `redmadrobot.root-project` to project that will be considered as "root":
 ```kotlin
 plugins {
     id("redmadrobot.root-project") version "0.11"

--- a/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -20,18 +20,21 @@ public class AndroidApplicationPlugin : BaseAndroidPlugin() {
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.application")
 
-        configureApp(redmadrobotExtension)
+        configureApp(redmadrobotExtension, infrastructureRootProject)
     }
 }
 
-private fun Project.configureApp(extension: RedmadrobotExtension) = android<AppExtension> {
+private fun Project.configureApp(
+    extension: RedmadrobotExtension,
+    infrastructureRootProject: Project,
+) = android<AppExtension> {
     defaultConfig {
         // Keep only 'ru' resources
         resConfig("ru")
 
         // Collect proguard rules from 'proguard' dir
         setProguardFiles(
-            rootProject.fileTree("proguard").files.filter { it.endsWith(".pro") } +
+            infrastructureRootProject.fileTree("proguard").files.filter { it.endsWith(".pro") } +
                 getDefaultProguardFile("proguard-android-optimize.txt"),
         )
 

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -13,7 +13,7 @@ import com.redmadrobot.build.internal.detekt.CollectGitDiffFilesTask.ChangeType
 import com.redmadrobot.build.internal.detekt.CollectGitDiffFilesTask.FilterParams
 import com.redmadrobot.build.internal.detektPlugins
 import com.redmadrobot.build.internal.getFileIfExists
-import com.redmadrobot.build.internal.isRootInfrastructureProject
+import com.redmadrobot.build.internal.isInfrastructureRootProject
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -75,7 +75,7 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension, inf
         description = "Runs over whole code base without the starting overhead for each module."
     }
 
-    if (project.isRootInfrastructureProject) {
+    if (project.isInfrastructureRootProject) {
         val variantRegex = Regex("^detekt($BASELINE_KEYWORD)?([A-Za-z]+)All$")
         val startTask = gradle.startParameter.taskNames.find { it.contains(variantRegex) }
         if (startTask != null && startTask != "detekt${BASELINE_KEYWORD}All") {

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -13,7 +13,7 @@ import com.redmadrobot.build.internal.detekt.CollectGitDiffFilesTask.ChangeType
 import com.redmadrobot.build.internal.detekt.CollectGitDiffFilesTask.FilterParams
 import com.redmadrobot.build.internal.detektPlugins
 import com.redmadrobot.build.internal.getFileIfExists
-import com.redmadrobot.build.internal.isRoot
+import com.redmadrobot.build.internal.isRootInfrastructureProject
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -34,11 +34,10 @@ public class DetektPlugin : InfrastructurePlugin() {
         apply(plugin = "io.gitlab.arturbosch.detekt")
 
         configureDependencies()
-        configureDetektTasks(redmadrobotExtension)
+        configureDetektTasks(redmadrobotExtension, infrastructureRootProject)
     }
 
     internal companion object {
-
         const val BASELINE_KEYWORD = "Baseline"
     }
 }
@@ -53,30 +52,30 @@ private fun Project.configureDependencies() {
     }
 }
 
-private fun Project.configureDetektTasks(extension: RedmadrobotExtension) {
-    configureDetektFormatTask(extension)
-    configureDetektAllTasks(extension)
-    configureDetektDiffTask(extension)
+private fun Project.configureDetektTasks(extension: RedmadrobotExtension, infrastructureRootProject: Project) {
+    configureDetektFormatTask(extension, infrastructureRootProject)
+    configureDetektAllTasks(extension, infrastructureRootProject)
+    configureDetektDiffTask(extension, infrastructureRootProject)
 }
 
-private fun Project.configureDetektFormatTask(extension: RedmadrobotExtension) {
-    detektTask(extension, "detektFormat") {
+private fun Project.configureDetektFormatTask(extension: RedmadrobotExtension, infrastructureRootProject: Project) {
+    detektTask(extension, infrastructureRootProject, "detektFormat") {
         description = "Reformats whole code base."
         disableDefaultRuleSets = true
         autoCorrect = true
     }
 }
 
-private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension) {
-    detektTask(extension, "detektAll") {
+private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension, infrastructureRootProject: Project) {
+    detektTask(extension, infrastructureRootProject, "detektAll") {
         description = "Runs over whole code base without the starting overhead for each module."
     }
 
-    detektCreateBaselineTask(extension, "detekt${BASELINE_KEYWORD}All") {
+    detektCreateBaselineTask(extension, infrastructureRootProject, "detekt${BASELINE_KEYWORD}All") {
         description = "Runs over whole code base without the starting overhead for each module."
     }
 
-    if (project.isRoot) {
+    if (project.isRootInfrastructureProject) {
         val variantRegex = Regex("^detekt($BASELINE_KEYWORD)?([A-Za-z]+)All$")
         val startTask = gradle.startParameter.taskNames.find { it.contains(variantRegex) }
         if (startTask != null && startTask != "detekt${BASELINE_KEYWORD}All") {
@@ -85,7 +84,7 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension) {
             val isBaseline = taskData?.get(1)?.value == BASELINE_KEYWORD
 
             if (isBaseline) {
-                detektCreateBaselineTask(extension, startTask) {
+                detektCreateBaselineTask(extension, infrastructureRootProject, startTask) {
                     checkAllSubprojectsContainPlugin<DetektPlugin> { modulesNames ->
                         "Modules $modulesNames don't contain \"detekt\" or \"redmadrobot.detekt\" plugin"
                     }
@@ -101,7 +100,7 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension) {
                     setSource(allSources)
                 }
             } else {
-                detektTask(extension, startTask) {
+                detektTask(extension, infrastructureRootProject, startTask) {
                     checkAllSubprojectsContainPlugin<DetektPlugin> { modulesNames ->
                         "Modules $modulesNames don't contain \"detekt\" or \"redmadrobot.detekt\" plugin"
                     }
@@ -121,7 +120,7 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension) {
     }
 }
 
-private fun Project.configureDetektDiffTask(extension: RedmadrobotExtension) {
+private fun Project.configureDetektDiffTask(extension: RedmadrobotExtension, infrastructureRootProject: Project) {
     val detektDiffOptions = extension.detekt.detektDiffOptions.orNull
     if (detektDiffOptions != null && detektDiffOptions.baseBranch.isNotEmpty()) {
         val changedFilesFilter = FilterParams(
@@ -135,15 +134,16 @@ private fun Project.configureDetektDiffTask(extension: RedmadrobotExtension) {
             branch.set(detektDiffOptions.baseBranch)
         }
 
-        detektTask(extension, "detektDiff") {
+        detektTask(extension, infrastructureRootProject, "detektDiff") {
             description = "Check out only changed files versus the ${detektDiffOptions.baseBranch} branch"
-            setSource(rootProject.files(findChangedFiles.map { it.outputFiles.from }))
+            setSource(infrastructureRootProject.files(findChangedFiles.map { it.outputFiles.from }))
         }
     }
 }
 
 private inline fun Project.detektTask(
     extension: RedmadrobotExtension,
+    infrastructureRootProject: Project,
     name: String,
     crossinline configure: Detekt.() -> Unit,
 ): TaskProvider<Detekt> {
@@ -151,7 +151,7 @@ private inline fun Project.detektTask(
         parallel = true
         config.setFrom(provider { extension.configsDir.get().file("detekt/detekt.yml") })
         baseline.set(provider { extension.configsDir.getFileIfExists("detekt/baseline.xml") })
-        setSource(rootProject.files(rootProject.projectDir))
+        setSource(infrastructureRootProject.projectDir)
         reportsDir.set(extension.reportsDir.asFile)
         include("**/*.kt")
         include("**/*.kts")
@@ -169,6 +169,7 @@ private inline fun Project.detektTask(
 
 private inline fun Project.detektCreateBaselineTask(
     extension: RedmadrobotExtension,
+    infrastructureRootProject: Project,
     name: String,
     crossinline configure: DetektCreateBaselineTask.() -> Unit,
 ): TaskProvider<DetektCreateBaselineTask> {
@@ -176,7 +177,7 @@ private inline fun Project.detektCreateBaselineTask(
         parallel.set(true)
         config.setFrom(provider { extension.configsDir.get().file("detekt/detekt.yml") })
         baseline.set(provider { extension.configsDir.get().file("detekt/baseline.xml") })
-        setSource(rootProject.files(rootProject.projectDir))
+        setSource(infrastructureRootProject.projectDir)
         include("**/*.kt")
         include("**/*.kts")
         exclude("**/res/**")

--- a/infrastructure/src/main/kotlin/InfrastructurePlugin.kt
+++ b/infrastructure/src/main/kotlin/InfrastructurePlugin.kt
@@ -1,6 +1,7 @@
 package com.redmadrobot.build
 
 import com.redmadrobot.build.extension.RedmadrobotExtension
+import com.redmadrobot.build.internal.findInfrastructureRootProject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
@@ -14,12 +15,15 @@ public abstract class InfrastructurePlugin : Plugin<Project> {
     public lateinit var project: Project
         private set
 
+    protected lateinit var infrastructureRootProject: Project
+        private set
+
     protected val redmadrobotExtension: RedmadrobotExtension
-        get() = project.rootProject.extensions.getByType()
+        get() = infrastructureRootProject.extensions.getByType()
 
     /** @see configure */
     final override fun apply(target: Project) {
-        target.requireRootProjectPlugin()
+        infrastructureRootProject = target.requireInfrastructureRootProject()
         project = target
         target.configure()
     }
@@ -27,10 +31,11 @@ public abstract class InfrastructurePlugin : Plugin<Project> {
     protected abstract fun Project.configure()
 }
 
-private fun Project.requireRootProjectPlugin() {
-    check(rootProject.plugins.hasPlugin("redmadrobot.root-project")) {
+private fun Project.requireInfrastructureRootProject(): Project {
+    return checkNotNull(findInfrastructureRootProject()) {
         """
-        Plugin 'redmadrobot.root-project' not found. You should apply it to your root project:
+        Plugin 'redmadrobot.root-project' is not applied to any of projects in hierarchy.
+        You should apply it to the project you want to define as "root":
 
         plugins {
             id("redmadrobot.root-project") version "[LATEST_VERSION_HERE]"

--- a/infrastructure/src/main/kotlin/RootProjectPlugin.kt
+++ b/infrastructure/src/main/kotlin/RootProjectPlugin.kt
@@ -3,6 +3,7 @@ package com.redmadrobot.build
 import com.redmadrobot.build.extension.RedmadrobotExtension
 import com.redmadrobot.build.extension.RedmadrobotExtensionImpl
 import com.redmadrobot.build.extension.StaticAnalyzerSpec
+import com.redmadrobot.build.internal.findInfrastructureRootProject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
@@ -18,7 +19,8 @@ import org.gradle.kotlin.dsl.create
 public class RootProjectPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        check(target.rootProject == target) { "This plugin can be applied only to the root project." }
+        val rootProject = target.findInfrastructureRootProject()
+        if (rootProject != null) error("Root-project is already defined: $rootProject")
 
         target.configureExtension()
     }

--- a/infrastructure/src/main/kotlin/internal/Project.kt
+++ b/infrastructure/src/main/kotlin/internal/Project.kt
@@ -3,8 +3,14 @@ package com.redmadrobot.build.internal
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-internal val Project.isRoot: Boolean
-    get() = this == rootProject
+internal val Project.isRootInfrastructureProject: Boolean
+    get() = this == findInfrastructureRootProject()
+
+/** Returns project with applied root-project plugin or `null` if there are no such project. */
+internal tailrec fun Project.findInfrastructureRootProject(): Project? {
+    if (plugins.hasPlugin("redmadrobot.root-project")) return this
+    return parent?.findInfrastructureRootProject()
+}
 
 internal inline fun <reified T : Plugin<*>> Project.checkAllSubprojectsContainPlugin(lazyMessage: (String) -> String) {
     val missingPluginModules = subprojects.filterNot { subproject -> subproject.plugins.hasPlugin<T>() }

--- a/infrastructure/src/main/kotlin/internal/Project.kt
+++ b/infrastructure/src/main/kotlin/internal/Project.kt
@@ -3,12 +3,12 @@ package com.redmadrobot.build.internal
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-internal val Project.isRootInfrastructureProject: Boolean
-    get() = this == findInfrastructureRootProject()
+internal val Project.isInfrastructureRootProject: Boolean
+    get() = plugins.hasPlugin("redmadrobot.root-project")
 
 /** Returns project with applied root-project plugin or `null` if there are no such project. */
 internal tailrec fun Project.findInfrastructureRootProject(): Project? {
-    if (plugins.hasPlugin("redmadrobot.root-project")) return this
+    if (isInfrastructureRootProject) return this
     return parent?.findInfrastructureRootProject()
 }
 


### PR DESCRIPTION
Plugin `redmadrobot.root-project` now can be applied to any project that should be considered as "root" project for gradle-infrastructure.