### PR TITLE
Add property jvmTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added Detekt tasks `detekt[Variant]All` with type resolution
 - Added the `detektBaselineAll` task to create a baseline file for Detekt rules.
 - Added `detektBaseline[Variant]All` tasks to create a baseline file for Detekt rules with type resolution.
+- Added option `redmadrobot.jvmTarget` to specify target JVM for Kotlin and Java compilers.
 
 ### Changed
 

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -7,6 +7,7 @@ import com.redmadrobot.build.internal.configureKotlin
 import com.redmadrobot.build.internal.setTestOptions
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.android
 import org.gradle.kotlin.dsl.repositories
@@ -30,13 +31,17 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
             plugin("org.gradle.android.cache-fix")
         }
 
-        configureKotlin()
-        configureAndroid(redmadrobotExtension.android)
+        val extension = redmadrobotExtension
+        configureKotlin(extension.jvmTarget)
+        configureAndroid(extension.android, extension.jvmTarget)
         configureRepositories()
     }
 }
 
-private fun Project.configureAndroid(options: AndroidOptions) = android<BaseExtension> {
+private fun Project.configureAndroid(
+    options: AndroidOptions,
+    jvmTarget: Property<JavaVersion>,
+) = android<BaseExtension> {
     compileSdkVersion(options.compileSdk.get())
     options.buildToolsVersion.orNull?.let(::buildToolsVersion)
 
@@ -50,8 +55,8 @@ private fun Project.configureAndroid(options: AndroidOptions) = android<BaseExte
     if (requestedNdkVersion != null) ndkVersion = requestedNdkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = jvmTarget.get()
+        targetCompatibility = jvmTarget.get()
     }
 
     @Suppress("UnstableApiUsage")

--- a/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure/src/main/kotlin/KotlinLibraryPlugin.kt
@@ -32,7 +32,7 @@ public class KotlinLibraryPlugin : InfrastructurePlugin() {
         kotlin.explicitApi()
 
         val extension = redmadrobotExtension
-        configureKotlin()
+        configureKotlin(extension.jvmTarget)
         configureKotlinTest(extension.test)
         configureRepositories()
     }

--- a/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
+++ b/infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
@@ -1,7 +1,9 @@
 package com.redmadrobot.build.extension
 
 import com.redmadrobot.build.internal.findByName
+import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.create
 import kotlin.properties.ReadOnlyProperty
 
@@ -21,6 +23,12 @@ public interface RedmadrobotExtension :
     public var kotlinVersion: String
         set(value) = error("You should not use this.")
         get() = error("You should not use this.")
+
+    /**
+     * JVM version to be used as a target by Kotlin and Java compilers.
+     * By default, used 1.8.
+     */
+    public val jvmTarget: Property<JavaVersion>
 
     public companion object {
         /** Extension name. */

--- a/infrastructure/src/main/kotlin/extension/RedmadrobotExtensionImpl.kt
+++ b/infrastructure/src/main/kotlin/extension/RedmadrobotExtensionImpl.kt
@@ -1,9 +1,11 @@
 package com.redmadrobot.build.extension
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.newInstance
 import javax.inject.Inject
 
+@Suppress("LeakingThis")
 internal abstract class RedmadrobotExtensionImpl @Inject constructor(objects: ObjectFactory) : RedmadrobotExtension {
 
     override val publishing: PublishingOptions = objects.newInstance<PublishingOptionsImpl>()
@@ -22,5 +24,11 @@ internal abstract class RedmadrobotExtensionImpl @Inject constructor(objects: Ob
 
     override fun detekt(configure: DetektOptions.() -> Unit) {
         detekt.configure()
+    }
+
+    init {
+        jvmTarget
+            .convention(JavaVersion.VERSION_1_8)
+            .finalizeValueOnRead()
     }
 }

--- a/infrastructure/src/main/kotlin/internal/Kotlin.kt
+++ b/infrastructure/src/main/kotlin/internal/Kotlin.kt
@@ -3,13 +3,15 @@ package com.redmadrobot.build.internal
 import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.dsl.isRunningOnCi
 import com.redmadrobot.build.dsl.kotlinCompile
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 
-public fun InfrastructurePlugin.configureKotlin() {
+public fun InfrastructurePlugin.configureKotlin(jvmTargetProperty: Property<JavaVersion>) {
     val warningsAsErrors = project.getWarningsAsErrorsProperty()
     project.kotlinCompile {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = jvmTargetProperty.get().toString()
             allWarningsAsErrors = warningsAsErrors
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         }


### PR DESCRIPTION
Added option `redmadrobot.jvmTarget` to specify target JVM for Kotlin and Java compilers.