### PR TITLE
Add testTaskFilter to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added the `detektBaselineAll` task to create a baseline file for Detekt rules.
 - Added `detektBaseline[Variant]All` tasks to create a baseline file for Detekt rules with type resolution.
 - Added option `redmadrobot.jvmTarget` to specify target JVM for Kotlin and Java compilers.
+- Added option `redmadrobot.android.testTasksFilter` to filter tasks that should be run on ':test'.
 
 ### Changed
 

--- a/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/BaseAndroidPlugin.kt
@@ -75,9 +75,10 @@ private fun Project.configureAndroid(
             sourceSet.java.srcDirs(javaSrcDirs + kotlinSrcDirs)
         }
 
-        // Keep only release unit tests to reduce tests execution time
+        // Filter unit tests to be run with 'test' task
         tasks.named("test") {
-            setDependsOn(dependsOn.filter { it !is TaskProvider<*> || it.name.endsWith("ReleaseUnitTest") })
+            val testTasksFilter = options.testTasksFilter.get()
+            setDependsOn(dependsOn.filter { it !is TaskProvider<*> || testTasksFilter(it) })
         }
     }
 

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptions.kt
@@ -1,6 +1,7 @@
 package com.redmadrobot.build.extension
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.android as _android
 
 /** Settings for android modules. */
@@ -36,6 +37,15 @@ public interface AndroidOptions : TestOptionsSpec {
      * Uses default version for current Android Gradle Plugin if not configured.
      */
     public val buildToolsVersion: Property<String>
+
+    /**
+     * Filters test tasks that should be run on ':test'.
+     * It is useful if you don't want to run tests for all build variants when run 'test' task.
+     *
+     * Filter should return `true` if the task should be executed of `false`, otherwise.
+     * By default, it returns `true` only for release unit tests.
+     */
+    public val testTasksFilter: Property<(TaskProvider<*>) -> Boolean>
 
     public companion object {
         internal const val DEFAULT_MIN_API = 21

--- a/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
+++ b/infrastructure-android/src/main/kotlin/extension/AndroidOptionsImpl.kt
@@ -25,5 +25,8 @@ internal abstract class AndroidOptionsImpl @Inject constructor(objects: ObjectFa
             .finalizeValueOnRead()
         buildToolsVersion
             .finalizeValueOnRead()
+        testTasksFilter
+            .convention { taskProvider -> taskProvider.name.endsWith("ReleaseUnitTest") }
+            .finalizeValueOnRead()
     }
 }


### PR DESCRIPTION
Added option `redmadrobot.android.testTasksFilter` to filter tasks that should be run on ':test'.