### PR TITLE
Fixed regex for different root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fixed regex to create `detekt[Variant]All`, `detektBaseline[Variant]All` for a project with non gradle root. 
+
 ## [0.12] (2021-09-01)
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed regex to create `detekt[Variant]All`, `detektBaseline[Variant]All` for a project with non gradle root. 
+- Fixed regex to create `detekt[Variant]All`, `detektBaseline[Variant]All` when infrastructure root project differs from Gradle root project.
 
 ## [0.12] (2021-09-01)
 

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -76,15 +76,17 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension, inf
     }
 
     if (project.isInfrastructureRootProject) {
-        val variantRegex = Regex("^detekt($BASELINE_KEYWORD)?([A-Za-z]+)All$")
-        val startTask = gradle.startParameter.taskNames.find { it.contains(variantRegex) }
+        val variantRegex = Regex("detekt($BASELINE_KEYWORD)?([A-Za-z]+)All$")
+        val taskRegex = Regex("^(${project.path}:)?$variantRegex")
+        val startTask = gradle.startParameter.taskNames.find { it.contains(taskRegex) }
         if (startTask != null && startTask != "detekt${BASELINE_KEYWORD}All") {
             val taskData = variantRegex.find(startTask)?.groups
             val requiredVariant = taskData?.get(2)?.value.orEmpty()
             val isBaseline = taskData?.get(1)?.value == BASELINE_KEYWORD
+            val detektTaskName = taskData?.get(0)?.value ?: return
 
             if (isBaseline) {
-                detektCreateBaselineTask(extension, infrastructureRootProject, startTask) {
+                detektCreateBaselineTask(extension, infrastructureRootProject, detektTaskName) {
                     checkAllSubprojectsContainPlugin<DetektPlugin> { modulesNames ->
                         "Modules $modulesNames don't contain \"detekt\" or \"redmadrobot.detekt\" plugin"
                     }
@@ -100,7 +102,7 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension, inf
                     setSource(allSources)
                 }
             } else {
-                detektTask(extension, infrastructureRootProject, startTask) {
+                detektTask(extension, infrastructureRootProject, detektTaskName) {
                     checkAllSubprojectsContainPlugin<DetektPlugin> { modulesNames ->
                         "Modules $modulesNames don't contain \"detekt\" or \"redmadrobot.detekt\" plugin"
                     }

--- a/infrastructure/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure/src/main/kotlin/DetektPlugin.kt
@@ -80,10 +80,10 @@ private fun Project.configureDetektAllTasks(extension: RedmadrobotExtension, inf
         val taskRegex = Regex("^(${project.path}:)?$variantRegex")
         val startTask = gradle.startParameter.taskNames.find { it.contains(taskRegex) }
         if (startTask != null && startTask != "detekt${BASELINE_KEYWORD}All") {
-            val taskData = variantRegex.find(startTask)?.groups
-            val requiredVariant = taskData?.get(2)?.value.orEmpty()
-            val isBaseline = taskData?.get(1)?.value == BASELINE_KEYWORD
-            val detektTaskName = taskData?.get(0)?.value ?: return
+            val taskData = variantRegex.find(startTask)?.groupValues
+            val detektTaskName = taskData?.get(0) ?: return
+            val isBaseline = taskData[1] == BASELINE_KEYWORD
+            val requiredVariant = taskData[2]
 
             if (isBaseline) {
                 detektCreateBaselineTask(extension, infrastructureRootProject, detektTaskName) {


### PR DESCRIPTION
After https://github.com/RedMadRobot/gradle-infrastructure/pull/72 we can define gradle infrastructure anywhere, but detekt checks with type resolution have a regex that doesn't support this. This PR fixes this.