### PR TITLE
Add repo accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ apply {
 - Kotlin 1.5.30 -> 1.5.31
 - Detekt 1.18.1 -> 1.19.0
 
+### Added
+
+- Added repository extension `jitpack()` (#82)
+
 ### Changed
 
 - **Breaking change!** Repositories `ossrh` and `ossrhSnapshots` now use host `s01.oss.sonatype.org` by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ apply {
 
 ### Changed
 
+- **Breaking change!** Repositories `ossrh` and `ossrhSnapshots` now use host `s01.oss.sonatype.org` by default.
+  To keep legacy host `oss.sonatype.org`, use `ossrh(LEGACY)` instead.
 - **Breaking change!** Directory with ProGuard rules now intended to be in `application` project instead of root project.
 - Default `targetSdk` changed from 30 to 31.
 - Gradle updated to 7.3.1

--- a/infrastructure-common/src/main/kotlin/dsl/Repositories.kt
+++ b/infrastructure-common/src/main/kotlin/dsl/Repositories.kt
@@ -17,6 +17,24 @@ public fun Project.credentialsExist(name: String): Boolean {
 }
 
 /**
+ * Adds JitPack repo with name "jitpack".
+ * The URL used for the repository is `https://jitpack.io`.
+ *
+ * Usage:
+ * ```
+ * repositories {
+ *     jitpack()
+ * }
+ * ```
+ */
+public fun RepositoryHandler.jitpack(configure: MavenArtifactRepository.() -> Unit = {}): MavenArtifactRepository {
+    return maven("https://jitpack.io") {
+        name = "jitpack"
+        configure()
+    }
+}
+
+/**
  * Adds RMR Nexus repo with name "rmrNexus".
  * Credentials should be provided through project properties `rmrNexusUsername` and `rmrNexusPassword`.
  *

--- a/infrastructure-publish/src/main/kotlin/dsl/OssrhRepositories.kt
+++ b/infrastructure-publish/src/main/kotlin/dsl/OssrhRepositories.kt
@@ -7,7 +7,7 @@ import org.gradle.kotlin.dsl.credentials
 import org.gradle.kotlin.dsl.maven
 
 /**
- * Adds Sonatype OSSRH repository with name "ossrh".
+ * Adds Sonatype OSSRH repository with name "ossrh" and the specified [host].
  * Requires credentials to be specified in project properties `ossrhUsername` and `ossrhPassword`.
  *
  * See:
@@ -22,8 +22,11 @@ import org.gradle.kotlin.dsl.maven
  * ```
  * @see ossrhSnapshots
  */
-public fun RepositoryHandler.ossrh(configure: MavenArtifactRepository.() -> Unit = {}): MavenArtifactRepository {
-    return maven("https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+public fun RepositoryHandler.ossrh(
+    host: OssrhHost = OssrhHost.S01,
+    configure: MavenArtifactRepository.() -> Unit = {},
+): MavenArtifactRepository {
+    return maven("${host.value}/service/local/staging/deploy/maven2/") {
         name = "ossrh"
         credentials(PasswordCredentials::class)
         configure()
@@ -31,7 +34,7 @@ public fun RepositoryHandler.ossrh(configure: MavenArtifactRepository.() -> Unit
 }
 
 /**
- * Adds Sonatype OSSRH Snapshots repository with name "ossrhSnapshots".
+ * Adds Sonatype OSSRH Snapshots repository with name "ossrhSnapshots" and the specified [host].
  *
  * Example:
  * ```
@@ -42,10 +45,21 @@ public fun RepositoryHandler.ossrh(configure: MavenArtifactRepository.() -> Unit
  * @see ossrh
  */
 public fun RepositoryHandler.ossrhSnapshots(
+    host: OssrhHost = OssrhHost.S01,
     configure: MavenArtifactRepository.() -> Unit = {},
 ): MavenArtifactRepository {
-    return maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+    return maven("${host.value}/content/repositories/snapshots/") {
         name = "ossrhSnapshots"
         configure()
     }
+}
+
+/** OSSRH hosts. */
+public enum class OssrhHost(public val value: String) {
+
+    /** Host used since February 2021. */
+    S01("https://s01.oss.sonatype.org"),
+
+    /** Legacy host used before February 2021. */
+    LEGACY("https://oss.sonatype.org"),
 }


### PR DESCRIPTION
### Added

- #82

### Changed

- **Breaking change!** Repositories `ossrh` and `ossrhSnapshots` now use host `s01.oss.sonatype.org` by default.
  To keep legacy host `oss.sonatype.org`, use `ossrh(LEGACY)` instead.