### PR TITLE
Fix detekt compatibility with AGP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Kotlin 1.5.31 -> 1.6.10
 - JGit 5.12.0 -> 6.0.0
 
+### Added
+
+- Added workaround for the case when detekt ignores kotlin sources when run on Android project with type resolution (detekt/detekt#4177)
+
 ## [0.13] (2021-12-13)
 
 ### Change plugins naming convention

--- a/infrastructure-detekt/src/main/kotlin/DetektPlugin.kt
+++ b/infrastructure-detekt/src/main/kotlin/DetektPlugin.kt
@@ -32,6 +32,8 @@ public class DetektPlugin : InfrastructurePlugin() {
         configureDetektFormatTask(redmadrobotExtension)
         configureDetektAllTasks(redmadrobotExtension)
         configureDetektDiffTask(redmadrobotExtension, detektOptions)
+
+        applyAndroidSourceFixToAllProjects()
     }
 
     internal companion object {

--- a/infrastructure-detekt/src/main/kotlin/internal/AndroidKotlinDirectoryFix.kt
+++ b/infrastructure-detekt/src/main/kotlin/internal/AndroidKotlinDirectoryFix.kt
@@ -1,0 +1,33 @@
+package com.redmadrobot.build.detekt.internal
+
+import com.android.build.gradle.BaseExtension
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+
+/**
+ * Fix issue when Detekt ignores kotlin source directory if it is not added to javaDirectories in AGP.
+ * See: https://github.com/detekt/detekt/issues/4177
+ */
+internal fun Project.applyAndroidSourceFixToAllProjects() {
+    allprojects {
+        afterEvaluate {
+            if (isKotlinAndroidProject && hasDetektPlugin) fixDetektAndroidSources()
+        }
+    }
+}
+
+// Here are second afterEvaluate. Fix will not work without it
+private fun Project.fixDetektAndroidSources() = afterEvaluate {
+    val android = extensions.getByType<BaseExtension>()
+    android.variants?.forEach { variant ->
+        tasks.named<Detekt>("detekt${variant.name.capitalize()}") {
+            setSource(variant.sourceSets.map { it.kotlinDirectories })
+        }
+        tasks.named<DetektCreateBaselineTask>("detektBaseline${variant.name.capitalize()}") {
+            setSource(variant.sourceSets.map { it.kotlinDirectories })
+        }
+    }
+}

--- a/infrastructure-detekt/src/main/kotlin/internal/Project.kt
+++ b/infrastructure-detekt/src/main/kotlin/internal/Project.kt
@@ -1,6 +1,0 @@
-package com.redmadrobot.build.detekt.internal
-
-import org.gradle.api.Project
-
-internal val Project.hasKotlinPlugin: Boolean
-    get() = extensions.findByName("kotlin") != null

--- a/infrastructure-detekt/src/main/kotlin/internal/ProjectDsl.kt
+++ b/infrastructure-detekt/src/main/kotlin/internal/ProjectDsl.kt
@@ -1,0 +1,27 @@
+package com.redmadrobot.build.detekt.internal
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.Project
+
+internal val Project.hasKotlinPlugin: Boolean
+    get() = extensions.findByName("kotlin") != null
+
+internal val Project.isKotlinAndroidProject: Boolean
+    get() = plugins.hasPlugin("kotlin-android")
+
+internal val Project.hasDetektPlugin: Boolean
+    get() = plugins.hasPlugin<DetektPlugin>()
+
+@Suppress("DEPRECATION") // Is there the new API to get source sets for variants?
+internal val BaseExtension.variants: DomainObjectSet<out com.android.build.gradle.api.BaseVariant>?
+    get() = when (this) {
+        is AppExtension -> applicationVariants
+        is LibraryExtension -> libraryVariants
+        is TestExtension -> applicationVariants
+        else -> null
+    }


### PR DESCRIPTION
Added workaround for the case when detekt ignores kotlin sources when run on Android project with type resolution (detekt/detekt#4177)

Closes #95