### PR TITLE
v0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changes
 
 - Switch to experimental API added in AGP 7.0.0
+- Changed QA build type fallbacks from `[release]` to `[debug, release]`
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 
 - Fixed error when trying to override `jvmTarget` or `android` options or in subprojects
+- Use `jvmTarget` for java target and source compatibility (#93)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
   }
   ```
 - Apply Lint settings to android-library modules (#98)
+- Configuration caching support (experimental)
 
 ### Changed
 
+- **Breaking change:** property `isRunningOnCi` changed to an extension-property on `Project` for configuration caching support
 - Switch to experimental API added in AGP 7.0.0
 - Changed QA build type fallbacks from `[release]` to `[debug, release]`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Dependencies
+
+- Android Gradle Plugin 7.0.3 -> 7.0.4
+- Android cache fix Gradle plugin 2.4.5 -> 2.4.6
+
 ## [0.14] (2021-12-27)
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   ```
 - Apply Lint settings to android-library modules (#98)
 - Configuration caching support (experimental)
+- Version catalogs publication via `com.redmadrobot.publish`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changes
+
+- Switch to experimental API added in AGP 7.0.0
+
 ### Dependencies
 
 - Android Gradle Plugin 7.0.3 -> 7.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@
   ```
 - Apply Lint settings to android-library modules (#98)
 
-### Changes
+### Changed
 
 - Switch to experimental API added in AGP 7.0.0
 - Changed QA build type fallbacks from `[release]` to `[debug, release]`
+
+### Fixed
+
+- Fixed error when trying to override `jvmTarget` or `android` options or in subprojects
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
       }
   }
   ```
+- Apply Lint settings to android-library modules (#98)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Added
+
+- Shortcuts for easy access to QA build type:
+  ```kotlin
+  android {
+      buildTypes {
+          qa {
+              // ...
+          }
+      }
+  }
+  ```
+
 ### Changes
 
 - Switch to experimental API added in AGP 7.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,3 +48,6 @@ kotlin.code.style=official
 
 # Disable Android Studio version check to be able to use Intellij IDEA.
 android.injected.studio.version.check=false
+
+# Disable because we use Kotlin API level 1.4
+warningsAsErrors=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx1024m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx1024m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1024m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-infrastructure = "0.13"
+infrastructure = "0.14"
 
 [libraries]
 infrastructure-kotlin = { module = "com.redmadrobot.build:infrastructure-kotlin", version.ref = "infrastructure" }
 infrastructure-detekt = { module = "com.redmadrobot.build:infrastructure-detekt", version.ref = "infrastructure" }
 infrastructure-publish = { module = "com.redmadrobot.build:infrastructure-publish", version.ref = "infrastructure" }
-androidTools-gradle = "com.android.tools.build:gradle:7.0.3"
+androidTools-gradle = "com.android.tools.build:gradle:7.0.4"
 androidTools-common = "com.android.tools:common:30.0.4"
-androidGradleCacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.5"
+androidGradleCacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.6"
 detektGradle = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
 kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
-pluginPublish = "com.gradle.publish:plugin-publish-plugin:0.18.0"
+pluginPublish = "com.gradle.publish:plugin-publish-plugin:0.19.0"
 jgit = "org.eclipse.jgit:org.eclipse.jgit:6.0.0.202111291000-r"

--- a/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
@@ -1,7 +1,10 @@
+@file:Suppress("UnstableApiUsage") // We want to use new APIs
+
 package com.redmadrobot.build.android
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.redmadrobot.build.android.internal.android
+import com.redmadrobot.build.android.internal.androidFinalizeDsl
 import com.redmadrobot.build.dsl.BUILD_TYPE_DEBUG
 import com.redmadrobot.build.dsl.BUILD_TYPE_QA
 import com.redmadrobot.build.dsl.BUILD_TYPE_RELEASE
@@ -19,17 +22,13 @@ public class AndroidApplicationPlugin : BaseAndroidPlugin() {
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.application")
 
-        configureApp(configPlugin.androidOptions)
+        configureApp()
+        finalizeApp(configPlugin.androidOptions)
     }
 }
 
-@Suppress("UnstableApiUsage") // We want to use new APIs
-private fun Project.configureApp(
-    androidOptions: AndroidOptions,
-) = android<ApplicationExtension> {
+private fun Project.configureApp() = android<ApplicationExtension> {
     defaultConfig {
-        targetSdk = androidOptions.targetSdk.get()
-
         // Keep only 'ru' resources by default
         resourceConfigurations.add("ru")
 
@@ -69,6 +68,14 @@ private fun Project.configureApp(
             matchingFallbacks += listOf(BUILD_TYPE_DEBUG, BUILD_TYPE_RELEASE)
             signingConfig = signingConfigs.findByName(BUILD_TYPE_DEBUG)
         }
+    }
+}
+
+private fun Project.finalizeApp(
+    androidOptions: AndroidOptions,
+) = androidFinalizeDsl<ApplicationExtension> {
+    defaultConfig {
+        targetSdk = androidOptions.targetSdk.get()
     }
 }
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
@@ -68,7 +68,7 @@ private fun Project.configureApp(
             initWith(getByName(BUILD_TYPE_RELEASE))
             applicationIdSuffix = ".$BUILD_TYPE_QA"
             isDebuggable = true
-            matchingFallbacks += BUILD_TYPE_RELEASE
+            matchingFallbacks += listOf(BUILD_TYPE_DEBUG, BUILD_TYPE_RELEASE)
             signingConfig = signingConfigs.findByName(BUILD_TYPE_DEBUG)
         }
     }

--- a/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
@@ -1,7 +1,6 @@
 package com.redmadrobot.build.android
 
 import com.android.build.api.dsl.ApplicationExtension
-import com.redmadrobot.build.StaticAnalyzerSpec
 import com.redmadrobot.build.android.internal.android
 import com.redmadrobot.build.dsl.BUILD_TYPE_DEBUG
 import com.redmadrobot.build.dsl.BUILD_TYPE_QA
@@ -20,14 +19,13 @@ public class AndroidApplicationPlugin : BaseAndroidPlugin() {
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.application")
 
-        configureApp(configPlugin.androidOptions, redmadrobotExtension)
+        configureApp(configPlugin.androidOptions)
     }
 }
 
 @Suppress("UnstableApiUsage") // We want to use new APIs
 private fun Project.configureApp(
     androidOptions: AndroidOptions,
-    staticAnalyzerSpec: StaticAnalyzerSpec,
 ) = android<ApplicationExtension> {
     defaultConfig {
         targetSdk = androidOptions.targetSdk.get()
@@ -71,16 +69,6 @@ private fun Project.configureApp(
             matchingFallbacks += listOf(BUILD_TYPE_DEBUG, BUILD_TYPE_RELEASE)
             signingConfig = signingConfigs.findByName(BUILD_TYPE_DEBUG)
         }
-    }
-
-    lint {
-        isCheckDependencies = true
-        isAbortOnError = true
-        isWarningsAsErrors = true
-        xmlOutput = staticAnalyzerSpec.reportsDir.file("lint-results.xml").get().asFile
-        htmlOutput = staticAnalyzerSpec.reportsDir.file("lint-results.html").get().asFile
-        lintConfig = staticAnalyzerSpec.configsDir.file("lint/lint.xml").get().asFile
-        baselineFile = staticAnalyzerSpec.configsDir.file("lint/lint-baseline.xml").get().asFile
     }
 }
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
@@ -1,6 +1,7 @@
 package com.redmadrobot.build.android
 
 import com.redmadrobot.build.InfrastructurePlugin
+import com.redmadrobot.build.StaticAnalyzerSpec
 import com.redmadrobot.build.kotlin.KotlinConfigPlugin
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
@@ -20,6 +21,9 @@ public open class AndroidConfigPlugin : InfrastructurePlugin() {
 
     internal val jvmTarget: Property<JavaVersion>
         get() = redmadrobotExtension.jvmTarget
+
+    internal val staticAnalyzerSpec: StaticAnalyzerSpec
+        get() = redmadrobotExtension
 
     override fun Project.configure() {
         val kotlinConfigPlugin = plugins.apply(KotlinConfigPlugin::class)

--- a/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
@@ -5,7 +5,7 @@ import com.redmadrobot.build.StaticAnalyzerSpec
 import com.redmadrobot.build.kotlin.KotlinConfigPlugin
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.apply
 
 /**
@@ -19,7 +19,7 @@ public open class AndroidConfigPlugin : InfrastructurePlugin() {
     internal lateinit var androidOptions: AndroidOptionsImpl
         private set
 
-    internal val jvmTarget: Property<JavaVersion>
+    internal val jvmTarget: Provider<JavaVersion>
         get() = redmadrobotExtension.jvmTarget
 
     internal val staticAnalyzerSpec: StaticAnalyzerSpec

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -1,7 +1,10 @@
+@file:Suppress("UnstableApiUsage") // We want to use new APIs
+
 package com.redmadrobot.build.android
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.redmadrobot.build.android.internal.android
+import com.redmadrobot.build.android.internal.androidFinalizeDsl
 import com.redmadrobot.build.kotlin.internal.kotlin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -21,16 +24,16 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
         applyBaseAndroidPlugin("com.android.library")
         val androidOptions = configPlugin.androidOptions
 
-        @Suppress("UnstableApiUsage")
         android<LibraryExtension> {
-            defaultConfig {
-                targetSdk = androidOptions.targetSdk.get()
-            }
-
             buildFeatures {
                 buildConfig = false
                 resValues = false
                 androidResources = false
+            }
+        }
+        androidFinalizeDsl<LibraryExtension> {
+            defaultConfig {
+                targetSdk = androidOptions.targetSdk.get()
             }
         }
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -19,9 +19,14 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
 
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.library")
+        val androidOptions = configPlugin.androidOptions
 
+        @Suppress("UnstableApiUsage")
         android<LibraryExtension> {
-            @Suppress("UnstableApiUsage")
+            defaultConfig {
+                targetSdk = androidOptions.targetSdk.get()
+            }
+
             buildFeatures {
                 buildConfig = false
                 resValues = false

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -50,7 +50,9 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
 
 private fun Project.configureAndroid() = android<CommonExtension<*, *, *, *>> {
     // Set NDK version from env variable if exists
-    val requestedNdkVersion = System.getenv("ANDROID_NDK_VERSION")
+    val requestedNdkVersion = providers.environmentVariable("ANDROID_NDK_VERSION")
+        .forUseAtConfigurationTime()
+        .orNull
     if (requestedNdkVersion != null) ndkVersion = requestedNdkVersion
 
     buildFeatures {

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -49,6 +49,12 @@ public abstract class BaseAndroidPlugin : InfrastructurePlugin() {
 }
 
 private fun Project.configureAndroid() = android<CommonExtension<*, *, *, *>> {
+    // Compile SDK is configured in finalizeDsl block, so here we can specify any value
+    // Without this line finalizeDsl will not be called at all.
+    // TODO: Remove this hack, when the issue will be fixed
+    //  https://issuetracker.google.com/issues/215407138
+    compileSdk = -1
+
     // Set NDK version from env variable if exists
     val requestedNdkVersion = providers.environmentVariable("ANDROID_NDK_VERSION")
         .forUseAtConfigurationTime()

--- a/infrastructure-android/src/main/kotlin/android/internal/Accessors.kt
+++ b/infrastructure-android/src/main/kotlin/android/internal/Accessors.kt
@@ -1,15 +1,29 @@
+@file:Suppress("UnstableApiUsage") // We want to use new APIs
+
 package com.redmadrobot.build.android.internal
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.redmadrobot.build.android.AndroidOptions
 import com.redmadrobot.build.kotlin.TestOptions
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.getByName
 
-@Suppress("UnstableApiUsage")
 internal fun <T : CommonExtension<*, *, *, *>> Project.android(configure: T.() -> Unit) {
     extensions.configure("android", configure)
+}
+
+@JvmName("androidFinalizeDslCommon")
+internal fun Project.androidFinalizeDsl(configure: CommonExtension<*, *, *, *>.() -> Unit) {
+    androidFinalizeDsl<CommonExtension<*, *, *, *>>(configure)
+}
+
+internal fun <T : CommonExtension<*, *, *, *>> Project.androidFinalizeDsl(
+    configure: T.() -> Unit,
+) {
+    extensions.getByName<AndroidComponentsExtension<T, *, *>>("androidComponents")
+        .finalizeDsl { it.configure() }
 }
 
 internal val AndroidOptions.test: TestOptions

--- a/infrastructure-android/src/main/kotlin/android/internal/Accessors.kt
+++ b/infrastructure-android/src/main/kotlin/android/internal/Accessors.kt
@@ -1,15 +1,14 @@
 package com.redmadrobot.build.android.internal
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
 import com.redmadrobot.build.android.AndroidOptions
 import com.redmadrobot.build.kotlin.TestOptions
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.getByName
 
-internal val Project.android: BaseExtension get() = extensions.getByName<BaseExtension>("android")
-
-internal fun <T : BaseExtension> Project.android(configure: T.() -> Unit) {
+@Suppress("UnstableApiUsage")
+internal fun <T : CommonExtension<*, *, *, *>> Project.android(configure: T.() -> Unit) {
     extensions.configure("android", configure)
 }
 

--- a/infrastructure-android/src/main/kotlin/dsl/BuildTypes.kt
+++ b/infrastructure-android/src/main/kotlin/dsl/BuildTypes.kt
@@ -1,6 +1,8 @@
 package com.redmadrobot.build.dsl
 
+import com.android.build.api.dsl.BuildType
 import com.redmadrobot.build.kotlin.internal.findStringProperty
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 /** Debug build type name. */
@@ -23,3 +25,25 @@ internal fun Project.finalizeQaBuildType() {
     BUILD_TYPE_QA = findStringProperty("redmadrobot.android.build.type.qa") ?: BUILD_TYPE_QA
     qaBuildTypeFinalized = true
 }
+
+/**
+ * Shortcut extension field to get the predefined QA [BuildType].
+ */
+public val <BuildTypeT : BuildType> NamedDomainObjectContainer<BuildTypeT>.qa: BuildTypeT
+    get() = getByName(BUILD_TYPE_QA)
+
+/**
+ * Shortcut extension method to allow easy access to the predefined `qa` [BuildType]:
+ * ```
+ * android {
+ *     buildTypes {
+ *         qa {
+ *             // ...
+ *         }
+ *     }
+ * }
+ * ```
+ */
+public fun <BuildTypeT : BuildType> NamedDomainObjectContainer<BuildTypeT>.qa(
+    action: BuildTypeT.() -> Unit,
+): BuildTypeT = getByName(BUILD_TYPE_QA, action)

--- a/infrastructure-android/src/main/kotlin/dsl/SourceSets.kt
+++ b/infrastructure-android/src/main/kotlin/dsl/SourceSets.kt
@@ -2,7 +2,7 @@ package com.redmadrobot.build.dsl
 
 import com.android.SdkConstants.*
 import com.android.build.api.dsl.AndroidSourceSet
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Incubating
 import org.gradle.kotlin.dsl.get
 
@@ -20,7 +20,7 @@ import org.gradle.kotlin.dsl.get
  * ```
  */
 @Incubating
-public fun BaseExtension.addSharedSourceSetRoot(
+public fun CommonExtension<*, *, *, *>.addSharedSourceSetRoot(
     variant1: String,
     variant2: String,
     name: String = "$variant1${variant2.capitalize()}",

--- a/infrastructure-common/src/main/kotlin/dsl/Predicates.kt
+++ b/infrastructure-common/src/main/kotlin/dsl/Predicates.kt
@@ -1,5 +1,7 @@
 package com.redmadrobot.build.dsl
 
+import org.gradle.api.Project
+
 /** Returns `true` if build is running on CI. */
-public val isRunningOnCi: Boolean
-    get() = System.getenv("CI") == "true"
+public val Project.isRunningOnCi: Boolean
+    get() = providers.environmentVariable("CI").forUseAtConfigurationTime().orNull == "true"

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinConfigPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinConfigPlugin.kt
@@ -1,7 +1,9 @@
 package com.redmadrobot.build.kotlin
 
 import com.redmadrobot.build.InfrastructurePlugin
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 
 /**
  * Plugin that adds configurations for Kotlin projects.
@@ -13,6 +15,9 @@ public open class KotlinConfigPlugin : InfrastructurePlugin() {
 
     public lateinit var testOptions: TestOptionsImpl
         private set
+
+    internal val jvmTarget: Provider<JavaVersion>
+        get() = redmadrobotExtension.jvmTarget
 
     override fun Project.configure() {
         testOptions = createExtension("test")

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
@@ -5,7 +5,6 @@ import com.redmadrobot.build.kotlin.internal.configureKotlin
 import com.redmadrobot.build.kotlin.internal.java
 import com.redmadrobot.build.kotlin.internal.kotlin
 import com.redmadrobot.build.kotlin.internal.setTestOptions
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
@@ -24,18 +23,19 @@ public class KotlinLibraryPlugin : InfrastructurePlugin() {
         apply(plugin = "kotlin")
         val configPlugin = plugins.apply(KotlinConfigPlugin::class)
 
-        java {
-            targetCompatibility = JavaVersion.VERSION_1_8
-            sourceCompatibility = JavaVersion.VERSION_1_8
-        }
-
         // Enable Explicit API mode for libraries by default
         kotlin.explicitApi()
 
-        val extension = redmadrobotExtension
-        configureKotlin(extension.jvmTarget)
+        configureKotlin(configPlugin.jvmTarget)
         configureKotlinTest(configPlugin.testOptions)
         configureRepositories()
+
+        afterEvaluate {
+            java {
+                targetCompatibility = configPlugin.jvmTarget.get()
+                sourceCompatibility = configPlugin.jvmTarget.get()
+            }
+        }
     }
 }
 

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
@@ -13,7 +13,7 @@ public fun InfrastructurePlugin.configureKotlin(jvmTargetProperty: Provider<Java
         kotlinOptions {
             jvmTarget = jvmTargetProperty.get().toString()
             allWarningsAsErrors = warningsAsErrors
-            freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
         }
     }
 }

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
@@ -5,9 +5,9 @@ import com.redmadrobot.build.dsl.isRunningOnCi
 import com.redmadrobot.build.dsl.kotlinCompile
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
-public fun InfrastructurePlugin.configureKotlin(jvmTargetProperty: Property<JavaVersion>) {
+public fun InfrastructurePlugin.configureKotlin(jvmTargetProperty: Provider<JavaVersion>) {
     val warningsAsErrors = project.getWarningsAsErrorsProperty()
     project.kotlinCompile {
         kotlinOptions {

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/ProjectProperties.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/ProjectProperties.kt
@@ -7,5 +7,5 @@ internal fun Project.findBooleanProperty(propertyName: String): Boolean? {
 }
 
 public fun Project.findStringProperty(propertyName: String): String? {
-    return project.findProperty(propertyName) as? String
+    return providers.gradleProperty(propertyName).forUseAtConfigurationTime().orNull
 }

--- a/infrastructure-publish/src/main/kotlin/publish/PublishPlugin.kt
+++ b/infrastructure-publish/src/main/kotlin/publish/PublishPlugin.kt
@@ -29,6 +29,7 @@ public open class PublishPlugin : InfrastructurePlugin() {
             val publicationName = when {
                 plugins.hasPlugin("kotlin-android") -> configureAndroidPublication()
                 plugins.hasPlugin("java-gradle-plugin") && isPluginAutomatedPublishing -> configurePluginPublication()
+                plugins.hasPlugin("org.gradle.version-catalog") -> configureVersionCatalogPublication()
                 else -> configurePublication()
             }
 
@@ -77,6 +78,16 @@ public open class PublishPlugin : InfrastructurePlugin() {
         }
 
         return PLUGIN_PUBLICATION_NAME
+    }
+
+    private fun Project.configureVersionCatalogPublication(): String {
+        publishing {
+            publications.create<MavenPublication>(PUBLICATION_NAME) {
+                from(components["versionCatalog"])
+            }
+        }
+
+        return PUBLICATION_NAME
     }
 
     private fun Project.configurePublication(): String {


### PR DESCRIPTION
### Added

- Shortcuts for easy access to QA build type:
  ```kotlin
  android {
      buildTypes {
          qa {
              // ...
          }
      }
  }
  ```
- Apply Lint settings to android-library modules (#98)
- Configuration caching support (experimental)
- Version catalogs publication via `com.redmadrobot.publish` (closes #100)

### Changed

- **Breaking change:** property `isRunningOnCi` changed to an extension-property on `Project` for configuration caching support
- Switch to experimental API added in AGP 7.0.0
- Changed QA build type fallbacks from `[release]` to `[debug, release]`

### Fixed

- Fixed error when trying to override `jvmTarget` or `android` options or in subprojects
- Use `jvmTarget` for java target and source compatibility (#93)

### Dependencies

- Android Gradle Plugin 7.0.3 -> 7.0.4
- Android cache fix Gradle plugin 2.4.5 -> 2.4.6