### PR TITLE
AGP 7.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,12 @@ Minimal required AGP and KGP will always be specified in README.
 
 ### Changed
 
-- **android:** Default `targetSdk` changed from `32` to `33` (**POTENTIALLY BREAKING CHANGE**)
+**BREAKING CHANGES:**
+- **android:** Minimal required AGP version is `7.4.0`
+- **android:** Default `targetSdk` changed from `32` to `33`
+- **android:** Don't set `targetSdk` in library modules. This field is deprecated and doesn't take any effect since AGP 7.4 ([b/230625468](https://issuetracker.google.com/issues/230625468#comment5))
+
+Other changes:
 - Change target JDK for all plugins from 8 to 11
 - Update Gradle to 7.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Minimal required AGP and KGP will always be specified in README.
 - **android:** Don't set `targetSdk` in library modules. This field is deprecated and doesn't take any effect since AGP 7.4 ([b/230625468](https://issuetracker.google.com/issues/230625468#comment5))
 
 Other changes:
+- **android:** Removed workaround for [b/215407138](https://issuetracker.google.com/issues/215407138) that is fixed in AGP 7.4
 - Change target JDK for all plugins from 8 to 11
 - Update Gradle to 7.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Minimal required AGP and KGP will always be specified in README.
 
 ### Changed
 
+- **android:** Default `targetSdk` changed from `32` to `33` (**POTENTIALLY BREAKING CHANGE**)
+- Change target JDK for all plugins from 8 to 11
 - Update Gradle to 7.6.1
 
 ## [0.17] (2022-07-29)

--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ You can use two different approaches to add plugin as a build dependency:
 
 | gradle-infrastructure | Minimal KGP version | Minimal AGP version |
 |-----------------------|---------------------|---------------------|
-| 0.18                  | 1.7.10              | 7.1.0               |
+| 0.18                  | 1.7.10              | 7.4.0               |
+| 0.17                  | 1.7.10              | 7.1.0               |
 
 ### Configuration
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 }
 
 redmadrobot {
+    jvmTarget.set(JavaVersion.VERSION_11)
+
     publishing {
         signArtifacts.set(!isRunningOnCi)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ infrastructure = "0.17"
 infrastructure-kotlin = { module = "com.redmadrobot.build:infrastructure-kotlin", version.ref = "infrastructure" }
 infrastructure-detekt = { module = "com.redmadrobot.build:infrastructure-detekt", version.ref = "infrastructure" }
 infrastructure-publish = { module = "com.redmadrobot.build:infrastructure-publish", version.ref = "infrastructure" }
-androidTools-gradle = "com.android.tools.build:gradle:7.2.1"
-androidTools-common = "com.android.tools:common:30.2.1"
-androidGradleCacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.5.6"
+androidTools-gradle = "com.android.tools.build:gradle:7.4.2"
+androidTools-common = "com.android.tools:common:30.4.2"
+androidGradleCacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.7.0"
 detektGradle = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0"
 kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
 pluginPublish = "com.gradle.publish:plugin-publish-plugin:1.1.0"

--- a/infrastructure-android/build.gradle.kts
+++ b/infrastructure-android/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "Small plugins to reduce boilerplate in Android projects' Gradle build scripts."
 
-redmadrobot {
-    jvmTarget.set(JavaVersion.VERSION_11)
-}
-
 gradlePlugin {
     plugins {
         register("android-config") {

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -46,6 +46,12 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
     }
 }
 
+// Workaround to configure Explicit API mode in android library modules
+// Related issues:
+// https://youtrack.jetbrains.com/issue/KT-37652
+// https://issuetracker.google.com/issues/167819676
+// https://issuetracker.google.com/issues/168371736
+// TODO: Remove when the issue will be fixed
 private fun Project.configureExplicitApi(mode: ExplicitApiMode?) {
     if (mode == null) return
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -4,7 +4,6 @@ package com.redmadrobot.build.android
 
 import com.android.build.api.dsl.LibraryExtension
 import com.redmadrobot.build.android.internal.android
-import com.redmadrobot.build.android.internal.androidFinalizeDsl
 import com.redmadrobot.build.android.internal.projectProguardFiles
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.kotlin.internal.kotlin
@@ -25,7 +24,6 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
     @InternalGradleInfrastructureApi
     override fun Project.configure() {
         applyBaseAndroidPlugin("com.android.library")
-        val androidOptions = configPlugin.androidOptions
 
         android<LibraryExtension> {
             defaultConfig {
@@ -37,11 +35,6 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
                 buildConfig = false
                 resValues = false
                 androidResources = false
-            }
-        }
-        androidFinalizeDsl<LibraryExtension> {
-            defaultConfig {
-                targetSdk = androidOptions.targetSdk.get()
             }
         }
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
@@ -36,6 +36,6 @@ public interface AndroidOptions {
 
     public companion object {
         internal const val DEFAULT_MIN_API = 23
-        internal const val DEFAULT_TARGET_API = 32
+        internal const val DEFAULT_TARGET_API = 33
     }
 }

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -52,12 +52,6 @@ public abstract class BaseAndroidPlugin internal constructor() : InfrastructureP
 }
 
 private fun Project.configureAndroid() = android<CommonExtension<*, *, *, *>> {
-    // Compile SDK is configured in finalizeDsl block, so here we can specify any value
-    // Without this line finalizeDsl will not be called at all.
-    // TODO: Remove this hack, when the issue will be fixed
-    //  https://issuetracker.google.com/issues/215407138
-    compileSdk = -1
-
     // Set NDK version from env variable if exists
     val requestedNdkVersion = System.getenv("ANDROID_NDK_VERSION")
     if (requestedNdkVersion != null) ndkVersion = requestedNdkVersion


### PR DESCRIPTION
**BREAKING CHANGES:**
- **android:** Minimal required AGP version is `7.4.0`
- **android:** Default `targetSdk` changed from `32` to `33`
- **android:** Don't set `targetSdk` in library modules. This field is deprecated and doesn't take any effect since AGP 7.4 ([b/230625468](https://issuetracker.google.com/issues/230625468#comment5))

Other changes:
- **android:** Removed workaround for [b/215407138](https://issuetracker.google.com/issues/215407138) that is fixed in AGP 7.4
- Change target JDK for all plugins from 8 to 11