### PR TITLE
Cleaning

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="DetektProjectConfiguration">
-    <enableDetekt>true</enableDetekt>
-    <enableFormatting>true</enableFormatting>
-    <configPaths>$PROJECT_DIR$/config/detekt/detekt.yml</configPaths>
+  <component name="DetektPluginSettings">
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/config/detekt/detekt.yml" />
+      </list>
+    </option>
+    <option name="enableDetekt" value="true" />
+    <option name="enableForProjectResult" value="Accepted" />
+    <option name="enableFormatting" value="true" />
   </component>
 </project>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalDependencies">
-    <plugin id="detekt" min-version="1.19.0" />
+    <plugin id="detekt" min-version="2.0.0" />
     <plugin id="org.editorconfig.editorconfigjetbrains" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ android {
 
 ### Other Changes
 
+- **android:** Use `ANDROID_BUILD_TOOLS_VERSION` env variable for `buildToolsVersion` if the option is not configured (#132)
 - **android:** Remove the workaround for Explicit API enabling as the issue has been [fixed](https://youtrack.jetbrains.com/issue/KT-37652) in Kotlin 1.9
 - **android:** Remove disabling of build features `aidl`, `renderScript` and `buildConfig` as they are already disabled by default in new versions of AGP
 - **kotlin:** Deprecate accessor `kotlinCompile`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ android {
 ### Other Changes
 
 - **android:** Use `ANDROID_BUILD_TOOLS_VERSION` env variable for `buildToolsVersion` if the option is not configured (#132)
+- **android:** Add the option `redmadrobot.android.ndkVersion` to specify NDK version for all android modules
 - **android:** Remove the workaround for Explicit API enabling as the issue has been [fixed](https://youtrack.jetbrains.com/issue/KT-37652) in Kotlin 1.9
 - **android:** Remove disabling of build features `aidl`, `renderScript` and `buildConfig` as they are already disabled by default in new versions of AGP
 - **kotlin:** Deprecate accessor `kotlinCompile`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ android {
 
 ### :warning: BREAKING CHANGES
 
+- **common:** Deprecate `redmadrobot.jvmTarget` with deprecation level `Error`.
+  Use [JVM Toolchains](https://kotl.in/gradle/jvm/toolchain) instead to specify JVM target.
+  Kotlin, Android Gradle Plugin, detekt and many other tools have support for this mechanism,
+  In most cases, adding this into your `build.gradle.kts` should be enough:
+  ```kotlin
+  kotlin {
+      jvmToolchain(17)
+  }
+  ```
+  You can also configure [automatic toolchains downloading](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories).
 - **common:** Disable [automatic repositories adding](https://github.com/RedMadRobot/gradle-infrastructure#automatically-added-repositories) by default.
   If you rely on this feature, consider declaring required repositories explicitly, or enable it in `gradle.properties`:
   ```properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ android {
   redmadrobot.add.repositories=true
   ```
 - **android:** Default `targetSdk` changed from `33` to `34`
+- **android:** Do not add `LOCK_ORIENTATION` and `CRASH_REPORTS_ENABLED` variables to `BuildConfig` implicitly
 
 ### Other Changes
 
 - **android:** Remove the workaround for Explicit API enabling as the issue has been [fixed](https://youtrack.jetbrains.com/issue/KT-37652) in Kotlin 1.9
+- **android:** Remove disabling of build features `aidl`, `renderScript` and `buildConfig` as they are already disabled by default in new versions of AGP
 - **kotlin:** Deprecate accessor `kotlinCompile`.
   It is recommended to use `kotlin.compilerOptions { ... }` to configure compilation instead.
 - Update Gradle to `8.8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ android {
 
 ### :warning: BREAKING CHANGES
 
+- **common:** Disable [automatic repositories adding](https://github.com/RedMadRobot/gradle-infrastructure#automatically-added-repositories) by default.
+  If you rely on this feature, consider declaring required repositories explicitly, or enable it in `gradle.properties`:
+  ```properties
+  redmadrobot.add.repositories=true
+  ```
 - **android:** Default `targetSdk` changed from `33` to `34`
 
 ### Other Changes

--- a/README.md
+++ b/README.md
@@ -225,20 +225,19 @@ Common configurations for Android libraries and application.
 Both:
 - Specifies `jvmTarget` and `compatibility` 11
 - Specifies default compile, min and target SDK
-- Disables `aidl`, `renderScript` and `shaders` [build-features]
+- Disables `shaders` [build-features] by default
 - Applies [android-cache-fix-gradle-plugin](https://github.com/gradle/android-cache-fix-gradle-plugin)
 
 Library:
 - Applies plugin `com.android.library`
 - Adds all proguard files from `proguard` folder as `consumerProguardFiles`
-- Disables `buildConfig`, `androidResources` and `resValues` [build-features]
+- Disables `androidResources` and `resValues` [build-features] by default
 - Enables [explicit API mode][explicit-api]
 
 Application:
 - Applies plugin `com.android.application`
 - Adds all proguard files from `proguard` folder
 - Configures `debug`, `qa` and `release` build types
-- Adds `LOCK_ORIENTATION` and `CRASH_REPORTS_ENABLED` BuildConfig variables which `false` only for `debug` build type
 - Configures Android Lint [default options][lint-options]
 
 #### QA build type name configuration

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 Small plugins to reduce boilerplate in Gradle build scripts.
 
-> :warning: It is designed to use with Gradle Kotlin DSL and can't be used from Groovy DSL.
+> [!IMPORTANT]
+> These plugins are designed to be used with Gradle Kotlin DSL only.
 
 ---
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -24,7 +25,7 @@ Small plugins to reduce boilerplate in Gradle build scripts.
   - [Configuration](#configuration)
   - [Align version of all Kotlin libraries](#align-version-of-all-kotlin-libraries)
   - [Warnings as errors](#warnings-as-errors)
-  - [Share sources between build types](#share-sources-between-build-types)
+  - [Share sources between build variants](#share-sources-between-build-variants)
   - [Enable Detekt checks only on changed files](#enable-detekt-checks-only-on-changed-files)
   - [Configure JUnit test execution options](#configure-junit-test-execution-options)
   - [Automatically added repositories](#automatically-added-repositories)
@@ -109,7 +110,30 @@ android {
 
 ## Plugins
 
-[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggQlRcbnN1YmdyYXBoIGluZnJhc3RydWN0dXJlLWFuZHJvaWRcbiAgICBhbmRyb2lkLWNvbmZpZ1tjb20ucmVkbWFkcm9ib3QuYW5kcm9pZC1jb25maWddXG4gICAgY29tLnJlZG1hZHJvYm90LmFwcGxpY2F0aW9uIC0tPiBhbmRyb2lkLWNvbmZpZ1xuICAgIGNvbS5yZWRtYWRyb2JvdC5hbmRyb2lkLWxpYnJhcnkgLS0-IGFuZHJvaWQtY29uZmlnXG5lbmRcblxuc3ViZ3JhcGggaW5mcmFzdHJ1Y3R1cmUtZGV0ZWt0XG4gICAgY29tLnJlZG1hZHJvYm90LmRldGVrdFxuZW5kXG5cbnN1YmdyYXBoIGluZnJhc3RydWN0dXJlLWtvdGxpblxuICAgIGtvdGxpbi1jb25maWdbY29tLnJlZG1hZHJvYm90LmtvdGxpbi1jb25maWddXG4gICAgY29tLnJlZG1hZHJvYm90LmtvdGxpbi1saWJyYXJ5IC0tPiBrb3RsaW4tY29uZmlnXG5lbmRcblxuc3ViZ3JhcGggaW5mcmFzdHJ1Y3R1cmUtcHVibGlzaFxuICAgIHB1Ymxpc2gtY29uZmlnW2NvbS5yZWRtYWRyb2JvdC5wdWJsaXNoLWNvbmZpZ11cbiAgICBjb20ucmVkbWFkcm9ib3QucHVibGlzaCAtLT4gcHVibGlzaC1jb25maWdcbmVuZFxuXG5hbmRyb2lkLWNvbmZpZyAtLT4ga290bGluLWNvbmZpZyIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6dHJ1ZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOnRydWV9)](https://mermaid-js.github.io/mermaid-live-editor/edit/#eyJjb2RlIjoiZ3JhcGggQlRcbnN1YmdyYXBoIGluZnJhc3RydWN0dXJlLWFuZHJvaWRcbiAgICBhbmRyb2lkLWNvbmZpZ1tjb20ucmVkbWFkcm9ib3QuYW5kcm9pZC1jb25maWddXG4gICAgY29tLnJlZG1hZHJvYm90LmFwcGxpY2F0aW9uIC0tPiBhbmRyb2lkLWNvbmZpZ1xuICAgIGNvbS5yZWRtYWRyb2JvdC5hbmRyb2lkLWxpYnJhcnkgLS0-IGFuZHJvaWQtY29uZmlnXG5lbmRcblxuc3ViZ3JhcGggaW5mcmFzdHJ1Y3R1cmUtZGV0ZWt0XG4gICAgY29tLnJlZG1hZHJvYm90LmRldGVrdFxuZW5kXG5cbnN1YmdyYXBoIGluZnJhc3RydWN0dXJlLWtvdGxpblxuICAgIGtvdGxpbi1jb25maWdbY29tLnJlZG1hZHJvYm90LmtvdGxpbi1jb25maWddXG4gICAgY29tLnJlZG1hZHJvYm90LmtvdGxpbi1saWJyYXJ5IC0tPiBrb3RsaW4tY29uZmlnXG5lbmRcblxuc3ViZ3JhcGggaW5mcmFzdHJ1Y3R1cmUtcHVibGlzaFxuICAgIHB1Ymxpc2gtY29uZmlnW2NvbS5yZWRtYWRyb2JvdC5wdWJsaXNoLWNvbmZpZ11cbiAgICBjb20ucmVkbWFkcm9ib3QucHVibGlzaCAtLT4gcHVibGlzaC1jb25maWdcbmVuZFxuXG5hbmRyb2lkLWNvbmZpZyAtLT4ga290bGluLWNvbmZpZyIsIm1lcm1haWQiOiJ7XG4gIFwidGhlbWVcIjogXCJkZWZhdWx0XCJcbn0iLCJ1cGRhdGVFZGl0b3IiOnRydWUsImF1dG9TeW5jIjp0cnVlLCJ1cGRhdGVEaWFncmFtIjp0cnVlfQ)
+```mermaid
+graph BT
+subgraph infrastructure-android
+    android-config[com.redmadrobot.android-config]
+    com.redmadrobot.application --> android-config
+    com.redmadrobot.android-library --> android-config
+end
+
+subgraph infrastructure-detekt
+    com.redmadrobot.detekt
+end
+
+subgraph infrastructure-kotlin
+    kotlin-config[com.redmadrobot.kotlin-config]
+    com.redmadrobot.kotlin-library --> kotlin-config
+end
+
+subgraph infrastructure-publish
+    publish-config[com.redmadrobot.publish-config]
+    com.redmadrobot.publish --> publish-config
+end
+
+android-config --> kotlin-config
+```
 
 ### kotlin-library
 
@@ -221,22 +245,24 @@ publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
 
 Common configurations for Android libraries and application.
 
-Both:
+[Both][BaseAndroidPlugin]:
 - Specifies default compile, min and target SDK
 - Disables `shaders` [build-features] by default
 - Applies [android-cache-fix-gradle-plugin](https://github.com/gradle/android-cache-fix-gradle-plugin)
+- Configures Android Lint with [defaults][lint-options]
+- [Filters tests][testTaskFilter] to be run on `test` task according to the config.
+  By default, keeps only tests for build type `release`.
 
-Library:
+[Library][AndroidLibraryPlugin]:
 - Applies plugin `com.android.library`
 - Adds all proguard files from `proguard` folder as `consumerProguardFiles`
 - Disables `androidResources` and `resValues` [build-features] by default
 - Enables [explicit API mode][explicit-api]
 
-Application:
+[Application][AndroidApplicationPlugin]:
 - Applies plugin `com.android.application`
 - Adds all proguard files from `proguard` folder
 - Configures `debug`, `qa` and `release` build types
-- Configures Android Lint [default options][lint-options]
 
 #### QA build type name configuration
 
@@ -288,15 +314,68 @@ See [compatibility table](#compatibility) to check what versions are compatible 
 
 ### Configuration
 
-You can configure the plugins with an extension named `redmadrobot`.
-Look for available properties with description in [RedmadrobotExtension].
+You can configure the plugins via the `redmadrobot` extension.
+Here are listed all available options, with their default values:
 
-The extension should be configured in root project.
 ```kotlin
-// root project build.gradle.kts
-
 redmadrobot {
-    configsDir = file("path/to/configs/")
+    /* Common options */
+    // Directory with configs for static analyzers and other tools.
+    configsDir = file("config/")
+
+    // Directory with reports of static analyzers and other tools.
+    reportsDir = file("build/reports/")
+
+    /* `kotlin-config` options */
+    test {
+        // Specifies that JUnit Platform (JUnit 5) should be used to execute tests.
+        useJunitPlatform()
+
+        // Specifies that JUnit 4 should be used to execute tests.
+        useJunit()
+    }
+
+    /* `android-config` options */
+    android {
+        // minSdk to be used in all android modules.
+        minSdk = 23
+
+        // targetSdk to be used in all android modules.
+        targetSdk = 34
+
+        // compileSdk to be used in all android modules
+        compileSdk = "34"
+
+        // Build Tools version to be used in all android modules.
+        buildToolsVersion = System.getenv("ANDROID_BUILD_TOOLS_VERSION")
+
+        // Filter for test tasks that should be run on ':test'.
+        testTasksFilter = { taskProvider -> taskProvider.name.endsWith("ReleaseUnitTest") }
+    
+        // Overrides of test configuration for android projects
+        test { /* ... */ }
+    }
+    
+    /* `detekt` options */
+    detekt {
+        // Enable Detekt checks only for modified files
+        // (Disabled by default)
+        checkOnlyDiffWithBranch(branch = "main") {
+            fileExtensions = setOf(".kt", ".kts")
+        }
+    }
+
+    /* `publish-config` options */
+    publishing {
+        // Enables artifacts signing before publication.
+        signArtifacts = false
+
+        // Use gpg-agent to sign artifacts. Has effect only if signArtifacts is `true`.
+        useGpgAgent = true
+
+        // Configures POM file for this project and its subprojects.
+        pom { /* ... */ }
+    }
 }
 ```
 
@@ -337,18 +416,19 @@ You can change it by defining the `warningsAsErrors` project property.
 
 [Read more about Gradle project properties][project-properties]
 
-### Share sources between build types
+### Share sources between build variants
 
-You can share sources between two build types.  
-For example, you need to use debug panel in both debug and QA builds, and don't want to write similar duplicating code for each of these build types.
-You can do it with one line with [addSharedSourceSetRoot] extension-function:
+You can share sources between two build variants.  
+For example, you need to use debug panel in both "debug" and "QA" builds, and don't want to duplicate code for each of these build types.
+You can do it in one line with [addSharedSourceSetRoot] extension-function:
+
 ```kotlin
 android {
     // We need to share sources between debug and QA builds
-    addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_QA)
+    sourceSet.addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_QA)
 
-    // We can specify name for the source set root if need
-    addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_QA, name = "debugPanel")
+    // We can specify a name for the source set root if needed
+    sourceSet.addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_QA, name = "debugPanel")
 }
 ```
 
@@ -495,7 +575,7 @@ Execution failed for task ':app:stripDebugDebugSymbols'.
 It is because NDK version on CI differs from a requested version.
 You can change requested version by setting `android.ndkVersion`.
 
-Plugins `com.redmadrobot.android-library` and `com.redmadrobot.application` by default apply NDK version from env variable `ANDROID_NDK_VERSION` if it set.
+Plugins `com.redmadrobot.android-library` and `com.redmadrobot.application` by default apply NDK version from env variable `ANDROID_NDK_VERSION` if it is set.
 
 ### `Could not resolve` or `Could not find` dependencies
 
@@ -535,11 +615,14 @@ For major changes, please open an issue first to discuss what you would like to 
 [MIT][license]
 
 [samples]: samples/
-[RedmadrobotExtension]: infrastructure/src/main/kotlin/extension/RedmadrobotExtension.kt
 [MavenPom]: infrastructure/src/main/kotlin/dsl/MavenPom.kt
 [predicates]: infrastructure/src/main/kotlin/dsl/PublishingPredicates.kt
 [addSharedSourceSetRoot]: infrastructure-android/src/main/kotlin/dsl/SourceSets.kt
-[lint-options]: https://github.com/RedMadRobot/gradle-infrastructure/blob/2e96c04cbb9d15ca508d1d4b4a8b1e2da4bab6af/infrastructure/src/main/kotlin/AndroidApplicationPlugin.kt#L63-L72
+[lint-options]: infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt#L76-L80
+[testTaskFilter]: infrastructure-android/src/main/kotlin/android/AndroidOptions.kt#L28-L35
+[BaseAndroidPlugin]: infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+[AndroidLibraryPlugin]: infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+[AndroidApplicationPlugin]: infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
 
 [infrastructure]: #
 [itemsadapter]: https://github.com/RedMadRobot/itemsadapter

--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ redmadrobot {
         // Build Tools version to be used in all android modules.
         buildToolsVersion = System.getenv("ANDROID_BUILD_TOOLS_VERSION")
 
+        // NDK version to be used in all android modules.
+        ndkVersion = System.getenv("ANDROID_NDK_VERSION")
+
         // Filter for test tasks that should be run on ':test'.
         testTasksFilter = { taskProvider -> taskProvider.name.endsWith("ReleaseUnitTest") }
     

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Common configurations for pure Kotlin libraries.
 
 - Applies plugin `kotlin`
 - Specifies `jvmTarget` 11
-- Adds repository `mavenCentral` (see [Automatically added repositories](#automatically-added-repositories))
 - Enables [explicit API mode][explicit-api]
 
 ### publish
@@ -206,7 +205,6 @@ publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
 
 ### detekt
 
-- Adds repository `mavenCentral` (see [Automatically added repositories](#automatically-added-repositories))
 - Applies `detekt` plugin with `detekt-formatting`
 - Configures additional tasks:
     - `detektAll` - Runs Detekt over the whole codebase
@@ -228,7 +226,6 @@ Both:
 - Specifies `jvmTarget` and `compatibility` 11
 - Specifies default compile, min and target SDK
 - Disables `aidl`, `renderScript` and `shaders` [build-features]
-- Adds repositories `mavenCentral` and `google` (see [Automatically added repositories](#automatically-added-repositories))
 - Applies [android-cache-fix-gradle-plugin](https://github.com/gradle/android-cache-fix-gradle-plugin)
 
 Library:
@@ -424,16 +421,20 @@ redmadrobot {
 
 ### Automatically added repositories
 
-Infrastructure plugins automatically add repositories required to make project work:
+> [!WARNING]
+> This feature is deprecated and is disabled by default since v0.19
+> Currently you can enable this behavior, though this option may be deleted at some point.
+
+Infrastructure plugins can automatically add required repositories:
 
 - **kotlin** plugin adds `mavenCentral` repo
 - **detekt** plugin adds `mavenCentral` repo
 - **android** plugins add `mavenCentral` and `google` repos
 
-In the case you don't want these repositories to be added automatically, you can disable this behavior via flag in `gradle.properties`:
+This feature should be enabled by flag in `gradle.properties`:
 
 ```properties
-redmadrobot.add.repositories=false
+redmadrobot.add.repositories=true
 ```
 
 ## Samples

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ android {
 Common configurations for pure Kotlin libraries.
 
 - Applies plugin `kotlin`
-- Specifies `jvmTarget` 11
 - Enables [explicit API mode][explicit-api]
 
 ### publish
@@ -223,7 +222,6 @@ publishing.publications.getByName<MavenPublication>(PUBLICATION_NAME) {
 Common configurations for Android libraries and application.
 
 Both:
-- Specifies `jvmTarget` and `compatibility` 11
 - Specifies default compile, min and target SDK
 - Disables `shaders` [build-features] by default
 - Applies [android-cache-fix-gradle-plugin](https://github.com/gradle/android-cache-fix-gradle-plugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,4 @@
-import com.redmadrobot.build.dsl.developer
-import com.redmadrobot.build.dsl.isRunningOnCi
-import com.redmadrobot.build.dsl.mit
-import com.redmadrobot.build.dsl.setGitHubProject
+import com.redmadrobot.build.dsl.*
 
 plugins {
     id("com.redmadrobot.detekt")

--- a/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
@@ -11,10 +11,7 @@ import com.redmadrobot.build.android.internal.android
 import com.redmadrobot.build.android.internal.androidComponents
 import com.redmadrobot.build.android.internal.projectProguardFiles
 import com.redmadrobot.build.android.task.MakeDebuggableTask
-import com.redmadrobot.build.dsl.BUILD_TYPE_DEBUG
-import com.redmadrobot.build.dsl.BUILD_TYPE_QA
-import com.redmadrobot.build.dsl.BUILD_TYPE_RELEASE
-import com.redmadrobot.build.dsl.finalizeQaBuildType
+import com.redmadrobot.build.dsl.*
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
@@ -44,9 +41,6 @@ private fun Project.configureApp() = android<ApplicationExtension> {
     defaultConfig {
         // Collect proguard rules from 'proguard' dir
         setProguardFiles(projectProguardFiles() + getDefaultProguardFile("proguard-android-optimize.txt"))
-
-        buildConfigField("boolean", VAR_LOCK_ORIENTATION, "true")
-        buildConfigField("boolean", VAR_CRASH_REPORTS_ENABLED, "true")
     }
 
     finalizeQaBuildType()
@@ -56,9 +50,6 @@ private fun Project.configureApp() = android<ApplicationExtension> {
             isDebuggable = true
             isMinifyEnabled = false
             isShrinkResources = false
-
-            buildConfigField("boolean", VAR_LOCK_ORIENTATION, "false")
-            buildConfigField("boolean", VAR_CRASH_REPORTS_ENABLED, "false")
         }
 
         release {
@@ -73,10 +64,6 @@ private fun Project.configureApp() = android<ApplicationExtension> {
             applicationIdSuffix = ".$BUILD_TYPE_QA"
             matchingFallbacks += listOf(BUILD_TYPE_DEBUG, BUILD_TYPE_RELEASE)
             signingConfig = signingConfigs.findByName(BUILD_TYPE_DEBUG)
-
-            // We can not use isDebuggable = true here, so set DEBUG field ourselves.
-            // See `makeDebuggable` for more information
-            buildConfigField(type = "boolean", name = "DEBUG", value = "true")
         }
     }
 }
@@ -108,9 +95,14 @@ private fun ApplicationExtension.finalizeApp(
         xmlOutput = staticAnalyzerSpec.reportsDir.file("lint-results.xml").get().asFile
         htmlOutput = staticAnalyzerSpec.reportsDir.file("lint-results.html").get().asFile
     }
+
+    buildTypes {
+        if (buildFeatures.buildConfig == true) {
+            qa {
+                // We can not use isDebuggable = true here, so set DEBUG field ourselves.
+                // See `makeDebuggable` for more information
+                buildConfigField(type = "boolean", name = "DEBUG", value = "true")
+            }
+        }
+    }
 }
-
-// Constants
-
-private const val VAR_LOCK_ORIENTATION = "LOCK_ORIENTATION"
-private const val VAR_CRASH_REPORTS_ENABLED = "CRASH_REPORTS_ENABLED"

--- a/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidApplicationPlugin.kt
@@ -12,7 +12,6 @@ import com.redmadrobot.build.android.internal.androidComponents
 import com.redmadrobot.build.android.internal.projectProguardFiles
 import com.redmadrobot.build.android.task.MakeDebuggableTask
 import com.redmadrobot.build.dsl.*
-import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.register
@@ -23,12 +22,9 @@ import org.gradle.kotlin.dsl.register
  *
  * Tied to `com.redmadrobot.application` plugin ID.
  */
-public class AndroidApplicationPlugin : BaseAndroidPlugin() {
+public class AndroidApplicationPlugin : BaseAndroidPlugin("com.android.application") {
 
-    @InternalGradleInfrastructureApi
-    override fun Project.configure() {
-        applyBaseAndroidPlugin("com.android.application")
-
+    override fun Project.configure(configPlugin: AndroidConfigPlugin) {
         configureApp()
         androidComponents<ApplicationAndroidComponentsExtension> {
             onVariants(selector().withBuildType(BUILD_TYPE_QA)) { it.makeDebuggable(tasks) }

--- a/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidConfigPlugin.kt
@@ -5,10 +5,8 @@ import com.redmadrobot.build.StaticAnalyzerSpec
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.hasPlugin
 import com.redmadrobot.build.kotlin.KotlinConfigPlugin
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.internal.plugins.PluginRegistry
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.apply
 import javax.inject.Inject
 
@@ -24,9 +22,6 @@ public open class AndroidConfigPlugin @Inject constructor(
 
     internal lateinit var androidOptions: AndroidOptionsImpl
         private set
-
-    internal val jvmTarget: Provider<JavaVersion>
-        get() = redmadrobotExtension.jvmTarget
 
     internal val staticAnalyzerSpec: StaticAnalyzerSpec
         get() = redmadrobotExtension

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -28,7 +28,6 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
             }
 
             buildFeatures {
-                buildConfig = false
                 resValues = false
                 androidResources = false
             }

--- a/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidLibraryPlugin.kt
@@ -5,9 +5,8 @@ package com.redmadrobot.build.android
 import com.android.build.api.dsl.LibraryExtension
 import com.redmadrobot.build.android.internal.android
 import com.redmadrobot.build.android.internal.projectProguardFiles
-import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
-import com.redmadrobot.build.kotlin.internal.kotlin
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 /**
  * Plugin that applies default configurations for Android library project.
@@ -15,12 +14,9 @@ import org.gradle.api.Project
  *
  * Tied to `com.redmadrobot.android-library` plugin ID.
  */
-public class AndroidLibraryPlugin : BaseAndroidPlugin() {
+public class AndroidLibraryPlugin : BaseAndroidPlugin("com.android.library") {
 
-    @InternalGradleInfrastructureApi
-    override fun Project.configure() {
-        applyBaseAndroidPlugin("com.android.library")
-
+    override fun Project.configure(configPlugin: AndroidConfigPlugin) {
         android<LibraryExtension> {
             defaultConfig {
                 // Add all files from 'proguard' dir
@@ -34,6 +30,6 @@ public class AndroidLibraryPlugin : BaseAndroidPlugin() {
         }
 
         // Enable Explicit API mode for libraries by default
-        kotlin.explicitApi()
+        kotlinExtension.explicitApi()
     }
 }

--- a/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
@@ -6,22 +6,30 @@ import org.gradle.api.tasks.TaskProvider
 /** Options for android projects. */
 public interface AndroidOptions {
 
-    /** Minimal Android SDK to use across all android modules. */
+    /**
+     * Minimal Android SDK to be used in all android modules.
+     * By default, SDK 23 is used.
+     */
     public val minSdk: Property<Int>
 
-    /** Target Android SDK to use across all android modules. */
+    /**
+     * Target Android SDK to be used in all android modules.
+     * By default, SDK 34 is used.
+     */
     public val targetSdk: Property<Int>
 
     /**
-     * Compile Android SDK to use across all android modules.
+     * Compile Android SDK to be used in all android modules.
      * It can be version number ("33") or version code ("T").
      * Uses [targetSdk] as compile SDK if not configured.
      */
     public val compileSdk: Property<String>
 
     /**
-     * Build Tools version to use across all android modules.
-     * Uses default version for current Android Gradle Plugin if not configured.
+     * Build Tools version to be used in all android modules.
+     *
+     * By default, uses the version from environment variable `ANDROID_BUILD_TOOLS_VERSION`,
+     * or default version for current Android Gradle Plugin if the variable is not present.
      */
     public val buildToolsVersion: Property<String>
 

--- a/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidOptions.kt
@@ -34,6 +34,12 @@ public interface AndroidOptions {
     public val buildToolsVersion: Property<String>
 
     /**
+     * NDK to be used in all android modules.
+     * By default, uses the version from the environment variable `ANDROID_NDK_VERSION` if it is set.
+     */
+    public val ndkVersion: Property<String>
+
+    /**
      * Filters test tasks that should be run on ':test'.
      * It is useful if you don't want to run tests for all build variants when run 'test' task.
      *

--- a/infrastructure-android/src/main/kotlin/android/AndroidOptionsImpl.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidOptionsImpl.kt
@@ -5,11 +5,15 @@ import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.kotlin.TestOptions
 import com.redmadrobot.build.kotlin.TestOptionsImpl
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.create
+import javax.inject.Inject
 
 @OptIn(InternalGradleInfrastructureApi::class)
 @Suppress("LeakingThis")
-internal abstract class AndroidOptionsImpl : AndroidOptions, WithDefaults<AndroidOptionsImpl> {
+internal abstract class AndroidOptionsImpl @Inject constructor(
+    providers: ProviderFactory,
+) : AndroidOptions, WithDefaults<AndroidOptionsImpl> {
 
     private val testOptions: TestOptionsImpl
     private var areTestDefaultsSet = false
@@ -25,6 +29,7 @@ internal abstract class AndroidOptionsImpl : AndroidOptions, WithDefaults<Androi
             .convention(targetSdk.map(Int::toString))
             .finalizeValueOnRead()
         buildToolsVersion
+            .convention(providers.environmentVariable("ANDROID_BUILD_TOOLS_VERSION"))
             .finalizeValueOnRead()
         testTasksFilter
             .convention { taskProvider -> taskProvider.name.endsWith("ReleaseUnitTest") }

--- a/infrastructure-android/src/main/kotlin/android/AndroidOptionsImpl.kt
+++ b/infrastructure-android/src/main/kotlin/android/AndroidOptionsImpl.kt
@@ -31,6 +31,9 @@ internal abstract class AndroidOptionsImpl @Inject constructor(
         buildToolsVersion
             .convention(providers.environmentVariable("ANDROID_BUILD_TOOLS_VERSION"))
             .finalizeValueOnRead()
+        ndkVersion
+            .convention(providers.environmentVariable("ANDROID_NDK_VERSION"))
+            .finalizeValueOnRead()
         testTasksFilter
             .convention { taskProvider -> taskProvider.name.endsWith("ReleaseUnitTest") }
             .finalizeValueOnRead()
@@ -48,6 +51,7 @@ internal abstract class AndroidOptionsImpl @Inject constructor(
         targetSdk.convention(defaults.targetSdk)
         compileSdk.convention(defaults.compileSdk)
         buildToolsVersion.convention(defaults.buildToolsVersion)
+        ndkVersion.convention(defaults.ndkVersion)
         testTasksFilter.convention(defaults.testTasksFilter)
         setTestDefaults(defaults.testOptions)
     }

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -43,7 +43,7 @@ public abstract class BaseAndroidPlugin internal constructor(
             plugin("org.gradle.android.cache-fix")
         }
 
-        configPlugin.configureKotlin()
+        configureKotlin()
         configureAndroid()
         androidComponents {
             finalizeDsl { extension ->

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -56,10 +56,6 @@ public abstract class BaseAndroidPlugin internal constructor() : InfrastructureP
 }
 
 private fun Project.configureAndroid() = android {
-    // Set NDK version from env variable if exists
-    val requestedNdkVersion = System.getenv("ANDROID_NDK_VERSION")
-    if (requestedNdkVersion != null) ndkVersion = requestedNdkVersion
-
     buildFeatures {
         shaders = false
     }
@@ -78,6 +74,7 @@ private fun CommonExtension.applyAndroidOptions(
 ) {
     setCompileSdkVersion(options.compileSdk.get())
     options.buildToolsVersion.ifPresent { buildToolsVersion = it }
+    options.ndkVersion.ifPresent { ndkVersion = it }
 
     defaultConfig {
         minSdk = options.minSdk.get()

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -9,9 +9,7 @@ import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.addRepositoriesIfNeed
 import com.redmadrobot.build.kotlin.internal.configureKotlin
 import com.redmadrobot.build.kotlin.internal.setTestOptions
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
@@ -41,13 +39,12 @@ public abstract class BaseAndroidPlugin internal constructor() : InfrastructureP
             plugin("org.gradle.android.cache-fix")
         }
 
-        configureKotlin(configPlugin.jvmTarget)
+        configureKotlin()
         configureAndroid()
         androidComponents {
             finalizeDsl { extension ->
                 extension.applyAndroidOptions(
                     options = configPlugin.androidOptions,
-                    jvmTarget = configPlugin.jvmTarget,
                     staticAnalyzerSpec = configPlugin.staticAnalyzerSpec,
                 )
                 filterTestTaskDependencies(configPlugin.androidOptions)
@@ -77,7 +74,6 @@ private fun Project.configureAndroid() = android {
 @OptIn(InternalGradleInfrastructureApi::class)
 private fun CommonExtension.applyAndroidOptions(
     options: AndroidOptions,
-    jvmTarget: Provider<JavaVersion>,
     staticAnalyzerSpec: StaticAnalyzerSpec,
 ) {
     setCompileSdkVersion(options.compileSdk.get())
@@ -85,11 +81,6 @@ private fun CommonExtension.applyAndroidOptions(
 
     defaultConfig {
         minSdk = options.minSdk.get()
-    }
-
-    compileOptions {
-        sourceCompatibility = jvmTarget.get()
-        targetCompatibility = jvmTarget.get()
     }
 
     testOptions {

--- a/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
+++ b/infrastructure-android/src/main/kotlin/android/BaseAndroidPlugin.kt
@@ -64,8 +64,6 @@ private fun Project.configureAndroid() = android {
     if (requestedNdkVersion != null) ndkVersion = requestedNdkVersion
 
     buildFeatures {
-        aidl = false
-        renderScript = false
         shaders = false
     }
 

--- a/infrastructure-common/src/main/kotlin/RedmadrobotExtension.kt
+++ b/infrastructure-common/src/main/kotlin/RedmadrobotExtension.kt
@@ -8,8 +8,12 @@ public interface RedmadrobotExtension : StaticAnalyzerSpec {
 
     /**
      * JVM version to be used as a target by Kotlin and Java compilers.
-     * By default, used Java 11.
+     * Use [JVM Toolchains](https://kotl.in/gradle/jvm/toolchain) instead.
      */
+    @Deprecated(
+        "Use JVM Toolchains instead. See https://kotl.in/gradle/jvm/toolchain",
+        level = DeprecationLevel.ERROR
+    )
     public val jvmTarget: Property<JavaVersion>
 
     public companion object {

--- a/infrastructure-common/src/main/kotlin/RedmadrobotExtensionImpl.kt
+++ b/infrastructure-common/src/main/kotlin/RedmadrobotExtensionImpl.kt
@@ -1,7 +1,6 @@
 package com.redmadrobot.build
 
 import com.redmadrobot.build.internal.findByName
-import org.gradle.api.JavaVersion
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
@@ -13,9 +12,6 @@ internal abstract class RedmadrobotExtensionImpl @Inject constructor(
 ) : RedmadrobotExtension, ExtensionAware, WithDefaults<RedmadrobotExtensionImpl> {
 
     init {
-        jvmTarget
-            .convention(JavaVersion.VERSION_11)
-            .finalizeValueOnRead()
         configsDir
             .convention(layout.projectDirectory.dir(StaticAnalyzerSpec.DEFAULT_CONFIGS_DIR))
             .finalizeValueOnRead()
@@ -25,7 +21,6 @@ internal abstract class RedmadrobotExtensionImpl @Inject constructor(
     }
 
     override fun setDefaults(defaults: RedmadrobotExtensionImpl) {
-        jvmTarget.convention(defaults.jvmTarget)
         configsDir.convention(defaults.configsDir)
         reportsDir.convention(defaults.reportsDir)
     }

--- a/infrastructure-common/src/main/kotlin/StaticAnalyzerSpec.kt
+++ b/infrastructure-common/src/main/kotlin/StaticAnalyzerSpec.kt
@@ -5,10 +5,10 @@ import org.gradle.api.file.DirectoryProperty
 /** Options used for static analyzers' configurations. */
 public interface StaticAnalyzerSpec {
 
-    /** Directory where stored configs for static analyzers. */
+    /** Directory with configs for static analyzers and other tools. */
     public val configsDir: DirectoryProperty
 
-    /** Directory where will be stored static analyzers reports. */
+    /** Directory with reports of static analyzers and other tools. */
     public val reportsDir: DirectoryProperty
 
     public companion object {

--- a/infrastructure-common/src/main/kotlin/internal/ProjectOptions.kt
+++ b/infrastructure-common/src/main/kotlin/internal/ProjectOptions.kt
@@ -6,6 +6,6 @@ import org.gradle.kotlin.dsl.repositories
 
 @InternalGradleInfrastructureApi
 public fun Project.addRepositoriesIfNeed(block: RepositoryHandler.() -> Unit) {
-    val addRepositories = findBooleanProperty("redmadrobot.add.repositories") != false
+    val addRepositories = findBooleanProperty("redmadrobot.add.repositories") == true
     if (addRepositories) repositories(block)
 }

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinConfigPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinConfigPlugin.kt
@@ -3,10 +3,8 @@ package com.redmadrobot.build.kotlin
 import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.hasPlugin
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.internal.plugins.PluginRegistry
-import org.gradle.api.provider.Provider
 import javax.inject.Inject
 
 /**
@@ -22,9 +20,6 @@ public open class KotlinConfigPlugin @Inject constructor(
     @InternalGradleInfrastructureApi
     public lateinit var testOptions: TestOptionsImpl
         private set
-
-    internal val jvmTarget: Provider<JavaVersion>
-        get() = redmadrobotExtension.jvmTarget
 
     @InternalGradleInfrastructureApi
     override fun Project.configure() {

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
@@ -4,7 +4,6 @@ import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.addRepositoriesIfNeed
 import com.redmadrobot.build.kotlin.internal.configureKotlin
-import com.redmadrobot.build.kotlin.internal.java
 import com.redmadrobot.build.kotlin.internal.kotlin
 import com.redmadrobot.build.kotlin.internal.setTestOptions
 import org.gradle.api.Project
@@ -28,16 +27,9 @@ public class KotlinLibraryPlugin : InfrastructurePlugin() {
         // Enable Explicit API mode for libraries by default
         kotlin.explicitApi()
 
-        configureKotlin(configPlugin.jvmTarget)
+        configureKotlin()
         configureKotlinTest(configPlugin.testOptions)
         configureRepositories()
-
-        afterEvaluate {
-            java {
-                targetCompatibility = configPlugin.jvmTarget.get()
-                sourceCompatibility = configPlugin.jvmTarget.get()
-            }
-        }
     }
 }
 

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
@@ -1,10 +1,10 @@
 package com.redmadrobot.build.kotlin
 
-import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.addRepositoriesIfNeed
 import com.redmadrobot.build.kotlin.internal.configureKotlin
 import com.redmadrobot.build.kotlin.internal.setTestOptions
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
@@ -17,10 +17,14 @@ import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
  *
  * Tied to `com.redmadrobot.kotlin-library` plugin ID.
  */
-public class KotlinLibraryPlugin : InfrastructurePlugin() {
+public class KotlinLibraryPlugin : Plugin<Project> {
 
-    @InternalGradleInfrastructureApi
-    override fun Project.configure() {
+    override fun apply(target: Project) {
+        target.configure()
+    }
+
+    @OptIn(InternalGradleInfrastructureApi::class)
+    private fun Project.configure() {
         apply(plugin = "kotlin")
         val configPlugin = plugins.apply(KotlinConfigPlugin::class)
 

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/KotlinLibraryPlugin.kt
@@ -4,12 +4,12 @@ import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.addRepositoriesIfNeed
 import com.redmadrobot.build.kotlin.internal.configureKotlin
-import com.redmadrobot.build.kotlin.internal.kotlin
 import com.redmadrobot.build.kotlin.internal.setTestOptions
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 /**
  * Plugin that applies default configurations for Kotlin library project.
@@ -25,7 +25,7 @@ public class KotlinLibraryPlugin : InfrastructurePlugin() {
         val configPlugin = plugins.apply(KotlinConfigPlugin::class)
 
         // Enable Explicit API mode for libraries by default
-        kotlin.explicitApi()
+        kotlinExtension.explicitApi()
 
         configureKotlin()
         configureKotlinTest(configPlugin.testOptions)

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/TestOptions.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/TestOptions.kt
@@ -7,12 +7,15 @@ import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 /** Options used to configure tests. */
 public interface TestOptions {
 
-    /** Flag for using Junit Jupiter Platform. Use functions [useJunit] or [useJunitPlatform]. */
+    /**
+     * Flag for using Junit Jupiter Platform.
+     * Use functions [useJunitPlatform] and [useJunit] to change it.
+     */
     public val useJunitPlatform: Provider<Boolean>
 
-    /** Specifies that JUnit Platform (JUnit 5) should be used to execute the tests. */
+    /** Specifies that JUnit Platform (JUnit 5) should be used to execute tests. */
     public fun useJunitPlatform(configure: JUnitPlatformOptions.() -> Unit = {})
 
-    /** Specifies that JUnit should be used to execute the tests. */
+    /** Specifies that JUnit 4 should be used to execute tests. */
     public fun useJunit(configure: JUnitOptions.() -> Unit = {})
 }

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
@@ -4,18 +4,14 @@ import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.dsl.isRunningOnCi
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.findBooleanProperty
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 @InternalGradleInfrastructureApi
-public fun InfrastructurePlugin.configureKotlin(jvmTargetProperty: Provider<JavaVersion>) {
+public fun InfrastructurePlugin.configureKotlin() {
     val warningsAsErrors = project.getWarningsAsErrorsProperty()
     project.kotlinCompile {
         compilerOptions {
-            jvmTarget = JvmTarget.fromTarget(jvmTargetProperty.get().toString())
             allWarningsAsErrors = warningsAsErrors
             freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
         }

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/Kotlin.kt
@@ -1,6 +1,5 @@
 package com.redmadrobot.build.kotlin.internal
 
-import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.dsl.isRunningOnCi
 import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.internal.findBooleanProperty
@@ -8,9 +7,9 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
 
 @InternalGradleInfrastructureApi
-public fun InfrastructurePlugin.configureKotlin() {
-    val warningsAsErrors = project.getWarningsAsErrorsProperty()
-    project.kotlinCompile {
+public fun Project.configureKotlin() {
+    val warningsAsErrors = getWarningsAsErrorsProperty()
+    kotlinCompile {
         compilerOptions {
             allWarningsAsErrors = warningsAsErrors
             freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")

--- a/infrastructure-kotlin/src/main/kotlin/kotlin/internal/KotlinAccessors.kt
+++ b/infrastructure-kotlin/src/main/kotlin/kotlin/internal/KotlinAccessors.kt
@@ -1,22 +1,13 @@
 package com.redmadrobot.build.kotlin.internal
 
-import com.redmadrobot.build.InfrastructurePlugin
-import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 internal fun Project.java(configure: JavaPluginExtension.() -> Unit) {
     extensions.configure("java", configure)
 }
-
-@InternalGradleInfrastructureApi
-public val InfrastructurePlugin.kotlin: KotlinProjectExtension get() = project.kotlin
-
-internal val Project.kotlin: KotlinProjectExtension get() = extensions.getByName<KotlinProjectExtension>("kotlin")
 
 internal inline fun Project.kotlinCompile(crossinline configure: KotlinJvmCompile.() -> Unit) {
     tasks.withType<KotlinJvmCompile>().configureEach { configure() }

--- a/infrastructure-publish/src/main/kotlin/publish/PublishPlugin.kt
+++ b/infrastructure-publish/src/main/kotlin/publish/PublishPlugin.kt
@@ -1,13 +1,12 @@
 package com.redmadrobot.build.publish
 
 import com.android.build.api.dsl.LibraryExtension
-import com.redmadrobot.build.InfrastructurePlugin
 import com.redmadrobot.build.dsl.isReleaseVersion
-import com.redmadrobot.build.internal.InternalGradleInfrastructureApi
 import com.redmadrobot.build.publish.internal.isPluginAutomatedPublishing
 import com.redmadrobot.build.publish.internal.java
 import com.redmadrobot.build.publish.internal.publishing
 import com.redmadrobot.build.publish.internal.signing
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.*
@@ -18,10 +17,13 @@ import org.gradle.plugins.signing.Sign
  *
  * Tied to `com.redmadrobot.publish` plugin ID.
  */
-public open class PublishPlugin : InfrastructurePlugin() {
+public open class PublishPlugin : Plugin<Project> {
 
-    @InternalGradleInfrastructureApi
-    override fun Project.configure() {
+    override fun apply(target: Project) {
+        target.configure()
+    }
+
+    private fun Project.configure() {
         apply(plugin = "maven-publish")
         val configPlugin = plugins.apply(PublishConfigPlugin::class)
 

--- a/samples/android-application-multi/app/build.gradle.kts
+++ b/samples/android-application-multi/app/build.gradle.kts
@@ -15,11 +15,6 @@ android {
         // For example, specify instrumentation tests runner.
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-
-    // TODO: Remove after removal of implicitly added BuildConfig fields
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/android-application-multi/app/build.gradle.kts
+++ b/samples/android-application-multi/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.redmadrobot.application")
+    convention.jvm
 }
 
 // Plugin "com.redmadrobot.application" configures build types, SDK versions, proguard and so on.

--- a/samples/android-application-multi/build.gradle.kts
+++ b/samples/android-application-multi/build.gradle.kts
@@ -1,8 +1,5 @@
 plugins {
-    // Specify needed versions of AGP and KGP
-    id("com.android.application") version "8.5.0" apply false
-    kotlin("android") version "2.0.0" apply false
-
+    // Versions of AGP and KGP are specified in buildSrc module
     id("com.redmadrobot.android-config") version "0.19-SNAPSHOT"
 }
 

--- a/samples/android-application-multi/buildSrc/build.gradle.kts
+++ b/samples/android-application-multi/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(kotlin("gradle-plugin", version = "2.0.0"))
+    implementation("com.android.tools.build:gradle:8.5.0")
+}

--- a/samples/android-application-multi/buildSrc/settings.gradle.kts
+++ b/samples/android-application-multi/buildSrc/settings.gradle.kts
@@ -1,0 +1,18 @@
+@file:Suppress("UnstableApiUsage")
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        mavenCentral()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
+    }
+}
+
+rootProject.name = "buildSrc"

--- a/samples/android-application-multi/buildSrc/src/main/kotlin/convention.jvm.gradle.kts
+++ b/samples/android-application-multi/buildSrc/src/main/kotlin/convention.jvm.gradle.kts
@@ -1,0 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+
+// Align JVM target across all modules
+kotlinExtension.jvmToolchain(17)

--- a/samples/android-application-multi/module1/build.gradle.kts
+++ b/samples/android-application-multi/module1/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.redmadrobot.android-library")
+    convention.jvm
 }
 
 android {

--- a/samples/android-application-multi/module2/build.gradle.kts
+++ b/samples/android-application-multi/module2/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.redmadrobot.android-library")
+    convention.jvm
 }
 
 // Explicit API is enabled by default, but we can disable it if needed

--- a/samples/android-application-multi/settings.gradle.kts
+++ b/samples/android-application-multi/settings.gradle.kts
@@ -1,10 +1,34 @@
+@file:Suppress("UnstableApiUsage")
+
 pluginManagement {
     repositories {
         // If we use SNAPSHOT version of infrastructure,
         // we should publish it to mavenLocal first
         mavenLocal()
         gradlePluginPortal()
-        google()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
+    }
+}
+
+// Configure repositories for all subprojects in one place
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
+        mavenCentral()
     }
 }
 

--- a/samples/android-application/app/build.gradle.kts
+++ b/samples/android-application/app/build.gradle.kts
@@ -1,6 +1,4 @@
-import com.redmadrobot.build.dsl.BUILD_TYPE_DEBUG
-import com.redmadrobot.build.dsl.BUILD_TYPE_QA
-import com.redmadrobot.build.dsl.addSharedSourceSetRoot
+import com.redmadrobot.build.dsl.*
 
 plugins {
     id("com.redmadrobot.application")
@@ -18,11 +16,6 @@ android {
         // If we need any additional configurations we still can add it.
         // For example we need to run instrumentation tests.
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    // TODO: Remove after removal of implicitly added BuildConfig fields
-    buildFeatures {
-        buildConfig = true
     }
 
     // If we need to share sources between two build types,

--- a/samples/android-application/app/build.gradle.kts
+++ b/samples/android-application/app/build.gradle.kts
@@ -25,6 +25,10 @@ android {
     sourceSets.addSharedSourceSetRoot(BUILD_TYPE_DEBUG, BUILD_TYPE_QA)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     // Align Kotlin version across all dependencies
     implementation(platform(kotlin("bom", version = "2.0.0")))

--- a/samples/android-application/settings.gradle.kts
+++ b/samples/android-application/settings.gradle.kts
@@ -1,10 +1,34 @@
+@file:Suppress("UnstableApiUsage")
+
 pluginManagement {
     repositories {
         // If we use SNAPSHOT version of infrastructure,
         // we should publish it to mavenLocal first
         mavenLocal()
         gradlePluginPortal()
-        google()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
+    }
+}
+
+// Configure repositories for all subprojects in one place
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
### :warning: BREAKING CHANGES

- **common:** Deprecate `redmadrobot.jvmTarget` with deprecation level `Error`.
  Use [JVM Toolchains](https://kotl.in/gradle/jvm/toolchain) instead to specify JVM target.
  Kotlin, Android Gradle Plugin, detekt and many other tools have support for this mechanism,
  In most cases, adding this into your `build.gradle.kts` should be enough:
  ```kotlin
  kotlin {
      jvmToolchain(17)
  }
  ```
  You can also configure [automatic toolchains downloading](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories).

- **common:** Disable [automatic repositories adding](https://github.com/RedMadRobot/gradle-infrastructure#automatically-added-repositories) by default.
  If you rely on this feature, consider declaring required repositories explicitly, or enable it in `gradle.properties`:
  ```properties
  redmadrobot.add.repositories=true
  ```

- **android:** Do not add `LOCK_ORIENTATION` and `CRASH_REPORTS_ENABLED` variables to `BuildConfig` implicitly

### Other Changes

- **android:** Use `ANDROID_BUILD_TOOLS_VERSION` env variable for `buildToolsVersion` if the option is not configured (closes #132)
- **android:** Add the option `redmadrobot.android.ndkVersion` to specify NDK version for all android modules
- **android:** Remove disabling of build features `aidl`, `renderScript` and `buildConfig` as they are already disabled by default in new versions of AGP